### PR TITLE
Farure/add config spaces shadows borders

### DIFF
--- a/dist/tailwind.css
+++ b/dist/tailwind.css
@@ -1004,6 +1004,138 @@ video {
   margin-left: calc(0.875rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
+.space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(.125rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(.125rem * var(--tw-space-y-reverse));
+}
+
+.space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(.125rem * var(--tw-space-x-reverse));
+  margin-left: calc(.125rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(.25rem * var(--tw-space-y-reverse));
+}
+
+.space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-xs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(.5rem * var(--tw-space-y-reverse));
+}
+
+.space-x-xs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-s > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(.75rem * var(--tw-space-y-reverse));
+}
+
+.space-x-s > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-m > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+}
+
+.space-x-m > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1rem * var(--tw-space-x-reverse));
+  margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-l > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+}
+
+.space-x-l > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+}
+
+.space-x-xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2rem * var(--tw-space-x-reverse));
+  margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2.5rem * var(--tw-space-y-reverse));
+}
+
+.space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(3rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(3rem * var(--tw-space-y-reverse));
+}
+
+.space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(3rem * var(--tw-space-x-reverse));
+  margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(4rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(4rem * var(--tw-space-y-reverse));
+}
+
+.space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(4rem * var(--tw-space-x-reverse));
+  margin-left: calc(4rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(8rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(8rem * var(--tw-space-y-reverse));
+}
+
+.space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(8rem * var(--tw-space-x-reverse));
+  margin-left: calc(8rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
 .-space-y-0 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
@@ -1422,6 +1554,138 @@ video {
   --tw-space-x-reverse: 0;
   margin-right: calc(-0.875rem * var(--tw-space-x-reverse));
   margin-left: calc(-0.875rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.125rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.125rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.125rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.125rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.25rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-xs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-xs > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-s > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-0.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-0.75rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-s > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-0.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(-0.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-m > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-m > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1rem * var(--tw-space-x-reverse));
+  margin-left: calc(-1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-l > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-1.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-l > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-1.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-1.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-2rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-2rem * var(--tw-space-x-reverse));
+  margin-left: calc(-2rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-2.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-2.5rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-2.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(-2.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-3rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-3rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-3rem * var(--tw-space-x-reverse));
+  margin-left: calc(-3rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-4rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-4rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-4rem * var(--tw-space-x-reverse));
+  margin-left: calc(-4rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.-space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(-8rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(-8rem * var(--tw-space-y-reverse));
+}
+
+.-space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(-8rem * var(--tw-space-x-reverse));
+  margin-left: calc(-8rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
 .space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -4080,6 +4344,50 @@ video {
   height: 0.875rem;
 }
 
+.h-3xs {
+  height: .125rem;
+}
+
+.h-xxs {
+  height: .25rem;
+}
+
+.h-xs {
+  height: .5rem;
+}
+
+.h-s {
+  height: .75rem;
+}
+
+.h-m {
+  height: 1rem;
+}
+
+.h-l {
+  height: 1.5rem;
+}
+
+.h-xl {
+  height: 2rem;
+}
+
+.h-xxl {
+  height: 2.5rem;
+}
+
+.h-3xl {
+  height: 3rem;
+}
+
+.h-4xl {
+  height: 4rem;
+}
+
+.h-5xl {
+  height: 8rem;
+}
+
 .h-1\/2 {
   height: 50%;
 }
@@ -4396,6 +4704,50 @@ video {
   margin: 0.875rem;
 }
 
+.m-3xs {
+  margin: .125rem;
+}
+
+.m-xxs {
+  margin: .25rem;
+}
+
+.m-xs {
+  margin: .5rem;
+}
+
+.m-s {
+  margin: .75rem;
+}
+
+.m-m {
+  margin: 1rem;
+}
+
+.m-l {
+  margin: 1.5rem;
+}
+
+.m-xl {
+  margin: 2rem;
+}
+
+.m-xxl {
+  margin: 2.5rem;
+}
+
+.m-3xl {
+  margin: 3rem;
+}
+
+.m-4xl {
+  margin: 4rem;
+}
+
+.m-5xl {
+  margin: 8rem;
+}
+
 .-m-0 {
   margin: 0px;
 }
@@ -4534,6 +4886,50 @@ video {
 
 .-m-3\.5 {
   margin: -0.875rem;
+}
+
+.-m-3xs {
+  margin: -0.125rem;
+}
+
+.-m-xxs {
+  margin: -0.25rem;
+}
+
+.-m-xs {
+  margin: -0.5rem;
+}
+
+.-m-s {
+  margin: -0.75rem;
+}
+
+.-m-m {
+  margin: -1rem;
+}
+
+.-m-l {
+  margin: -1.5rem;
+}
+
+.-m-xl {
+  margin: -2rem;
+}
+
+.-m-xxl {
+  margin: -2.5rem;
+}
+
+.-m-3xl {
+  margin: -3rem;
+}
+
+.-m-4xl {
+  margin: -4rem;
+}
+
+.-m-5xl {
+  margin: -8rem;
 }
 
 .my-0 {
@@ -4896,6 +5292,116 @@ video {
   margin-right: 0.875rem;
 }
 
+.my-3xs {
+  margin-top: .125rem;
+  margin-bottom: .125rem;
+}
+
+.mx-3xs {
+  margin-left: .125rem;
+  margin-right: .125rem;
+}
+
+.my-xxs {
+  margin-top: .25rem;
+  margin-bottom: .25rem;
+}
+
+.mx-xxs {
+  margin-left: .25rem;
+  margin-right: .25rem;
+}
+
+.my-xs {
+  margin-top: .5rem;
+  margin-bottom: .5rem;
+}
+
+.mx-xs {
+  margin-left: .5rem;
+  margin-right: .5rem;
+}
+
+.my-s {
+  margin-top: .75rem;
+  margin-bottom: .75rem;
+}
+
+.mx-s {
+  margin-left: .75rem;
+  margin-right: .75rem;
+}
+
+.my-m {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.mx-m {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.my-l {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.mx-l {
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+}
+
+.my-xl {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.mx-xl {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.my-xxl {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.mx-xxl {
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
+}
+
+.my-3xl {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}
+
+.mx-3xl {
+  margin-left: 3rem;
+  margin-right: 3rem;
+}
+
+.my-4xl {
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}
+
+.mx-4xl {
+  margin-left: 4rem;
+  margin-right: 4rem;
+}
+
+.my-5xl {
+  margin-top: 8rem;
+  margin-bottom: 8rem;
+}
+
+.mx-5xl {
+  margin-left: 8rem;
+  margin-right: 8rem;
+}
+
 .-my-0 {
   margin-top: 0px;
   margin-bottom: 0px;
@@ -5244,6 +5750,116 @@ video {
 .-mx-3\.5 {
   margin-left: -0.875rem;
   margin-right: -0.875rem;
+}
+
+.-my-3xs {
+  margin-top: -0.125rem;
+  margin-bottom: -0.125rem;
+}
+
+.-mx-3xs {
+  margin-left: -0.125rem;
+  margin-right: -0.125rem;
+}
+
+.-my-xxs {
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
+}
+
+.-mx-xxs {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
+.-my-xs {
+  margin-top: -0.5rem;
+  margin-bottom: -0.5rem;
+}
+
+.-mx-xs {
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+}
+
+.-my-s {
+  margin-top: -0.75rem;
+  margin-bottom: -0.75rem;
+}
+
+.-mx-s {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+}
+
+.-my-m {
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+}
+
+.-mx-m {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+.-my-l {
+  margin-top: -1.5rem;
+  margin-bottom: -1.5rem;
+}
+
+.-mx-l {
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+}
+
+.-my-xl {
+  margin-top: -2rem;
+  margin-bottom: -2rem;
+}
+
+.-mx-xl {
+  margin-left: -2rem;
+  margin-right: -2rem;
+}
+
+.-my-xxl {
+  margin-top: -2.5rem;
+  margin-bottom: -2.5rem;
+}
+
+.-mx-xxl {
+  margin-left: -2.5rem;
+  margin-right: -2.5rem;
+}
+
+.-my-3xl {
+  margin-top: -3rem;
+  margin-bottom: -3rem;
+}
+
+.-mx-3xl {
+  margin-left: -3rem;
+  margin-right: -3rem;
+}
+
+.-my-4xl {
+  margin-top: -4rem;
+  margin-bottom: -4rem;
+}
+
+.-mx-4xl {
+  margin-left: -4rem;
+  margin-right: -4rem;
+}
+
+.-my-5xl {
+  margin-top: -8rem;
+  margin-bottom: -8rem;
+}
+
+.-mx-5xl {
+  margin-left: -8rem;
+  margin-right: -8rem;
 }
 
 .mt-0 {
@@ -5822,6 +6438,182 @@ video {
   margin-left: 0.875rem;
 }
 
+.mt-3xs {
+  margin-top: .125rem;
+}
+
+.mr-3xs {
+  margin-right: .125rem;
+}
+
+.mb-3xs {
+  margin-bottom: .125rem;
+}
+
+.ml-3xs {
+  margin-left: .125rem;
+}
+
+.mt-xxs {
+  margin-top: .25rem;
+}
+
+.mr-xxs {
+  margin-right: .25rem;
+}
+
+.mb-xxs {
+  margin-bottom: .25rem;
+}
+
+.ml-xxs {
+  margin-left: .25rem;
+}
+
+.mt-xs {
+  margin-top: .5rem;
+}
+
+.mr-xs {
+  margin-right: .5rem;
+}
+
+.mb-xs {
+  margin-bottom: .5rem;
+}
+
+.ml-xs {
+  margin-left: .5rem;
+}
+
+.mt-s {
+  margin-top: .75rem;
+}
+
+.mr-s {
+  margin-right: .75rem;
+}
+
+.mb-s {
+  margin-bottom: .75rem;
+}
+
+.ml-s {
+  margin-left: .75rem;
+}
+
+.mt-m {
+  margin-top: 1rem;
+}
+
+.mr-m {
+  margin-right: 1rem;
+}
+
+.mb-m {
+  margin-bottom: 1rem;
+}
+
+.ml-m {
+  margin-left: 1rem;
+}
+
+.mt-l {
+  margin-top: 1.5rem;
+}
+
+.mr-l {
+  margin-right: 1.5rem;
+}
+
+.mb-l {
+  margin-bottom: 1.5rem;
+}
+
+.ml-l {
+  margin-left: 1.5rem;
+}
+
+.mt-xl {
+  margin-top: 2rem;
+}
+
+.mr-xl {
+  margin-right: 2rem;
+}
+
+.mb-xl {
+  margin-bottom: 2rem;
+}
+
+.ml-xl {
+  margin-left: 2rem;
+}
+
+.mt-xxl {
+  margin-top: 2.5rem;
+}
+
+.mr-xxl {
+  margin-right: 2.5rem;
+}
+
+.mb-xxl {
+  margin-bottom: 2.5rem;
+}
+
+.ml-xxl {
+  margin-left: 2.5rem;
+}
+
+.mt-3xl {
+  margin-top: 3rem;
+}
+
+.mr-3xl {
+  margin-right: 3rem;
+}
+
+.mb-3xl {
+  margin-bottom: 3rem;
+}
+
+.ml-3xl {
+  margin-left: 3rem;
+}
+
+.mt-4xl {
+  margin-top: 4rem;
+}
+
+.mr-4xl {
+  margin-right: 4rem;
+}
+
+.mb-4xl {
+  margin-bottom: 4rem;
+}
+
+.ml-4xl {
+  margin-left: 4rem;
+}
+
+.mt-5xl {
+  margin-top: 8rem;
+}
+
+.mr-5xl {
+  margin-right: 8rem;
+}
+
+.mb-5xl {
+  margin-bottom: 8rem;
+}
+
+.ml-5xl {
+  margin-left: 8rem;
+}
+
 .-mt-0 {
   margin-top: 0px;
 }
@@ -6382,6 +7174,182 @@ video {
   margin-left: -0.875rem;
 }
 
+.-mt-3xs {
+  margin-top: -0.125rem;
+}
+
+.-mr-3xs {
+  margin-right: -0.125rem;
+}
+
+.-mb-3xs {
+  margin-bottom: -0.125rem;
+}
+
+.-ml-3xs {
+  margin-left: -0.125rem;
+}
+
+.-mt-xxs {
+  margin-top: -0.25rem;
+}
+
+.-mr-xxs {
+  margin-right: -0.25rem;
+}
+
+.-mb-xxs {
+  margin-bottom: -0.25rem;
+}
+
+.-ml-xxs {
+  margin-left: -0.25rem;
+}
+
+.-mt-xs {
+  margin-top: -0.5rem;
+}
+
+.-mr-xs {
+  margin-right: -0.5rem;
+}
+
+.-mb-xs {
+  margin-bottom: -0.5rem;
+}
+
+.-ml-xs {
+  margin-left: -0.5rem;
+}
+
+.-mt-s {
+  margin-top: -0.75rem;
+}
+
+.-mr-s {
+  margin-right: -0.75rem;
+}
+
+.-mb-s {
+  margin-bottom: -0.75rem;
+}
+
+.-ml-s {
+  margin-left: -0.75rem;
+}
+
+.-mt-m {
+  margin-top: -1rem;
+}
+
+.-mr-m {
+  margin-right: -1rem;
+}
+
+.-mb-m {
+  margin-bottom: -1rem;
+}
+
+.-ml-m {
+  margin-left: -1rem;
+}
+
+.-mt-l {
+  margin-top: -1.5rem;
+}
+
+.-mr-l {
+  margin-right: -1.5rem;
+}
+
+.-mb-l {
+  margin-bottom: -1.5rem;
+}
+
+.-ml-l {
+  margin-left: -1.5rem;
+}
+
+.-mt-xl {
+  margin-top: -2rem;
+}
+
+.-mr-xl {
+  margin-right: -2rem;
+}
+
+.-mb-xl {
+  margin-bottom: -2rem;
+}
+
+.-ml-xl {
+  margin-left: -2rem;
+}
+
+.-mt-xxl {
+  margin-top: -2.5rem;
+}
+
+.-mr-xxl {
+  margin-right: -2.5rem;
+}
+
+.-mb-xxl {
+  margin-bottom: -2.5rem;
+}
+
+.-ml-xxl {
+  margin-left: -2.5rem;
+}
+
+.-mt-3xl {
+  margin-top: -3rem;
+}
+
+.-mr-3xl {
+  margin-right: -3rem;
+}
+
+.-mb-3xl {
+  margin-bottom: -3rem;
+}
+
+.-ml-3xl {
+  margin-left: -3rem;
+}
+
+.-mt-4xl {
+  margin-top: -4rem;
+}
+
+.-mr-4xl {
+  margin-right: -4rem;
+}
+
+.-mb-4xl {
+  margin-bottom: -4rem;
+}
+
+.-ml-4xl {
+  margin-left: -4rem;
+}
+
+.-mt-5xl {
+  margin-top: -8rem;
+}
+
+.-mr-5xl {
+  margin-right: -8rem;
+}
+
+.-mb-5xl {
+  margin-bottom: -8rem;
+}
+
+.-ml-5xl {
+  margin-left: -8rem;
+}
+
 .max-h-0 {
   max-height: 0px;
 }
@@ -6520,6 +7488,50 @@ video {
 
 .max-h-3\.5 {
   max-height: 0.875rem;
+}
+
+.max-h-3xs {
+  max-height: .125rem;
+}
+
+.max-h-xxs {
+  max-height: .25rem;
+}
+
+.max-h-xs {
+  max-height: .5rem;
+}
+
+.max-h-s {
+  max-height: .75rem;
+}
+
+.max-h-m {
+  max-height: 1rem;
+}
+
+.max-h-l {
+  max-height: 1.5rem;
+}
+
+.max-h-xl {
+  max-height: 2rem;
+}
+
+.max-h-xxl {
+  max-height: 2.5rem;
+}
+
+.max-h-3xl {
+  max-height: 3rem;
+}
+
+.max-h-4xl {
+  max-height: 4rem;
+}
+
+.max-h-5xl {
+  max-height: 8rem;
 }
 
 .max-h-full {
@@ -7296,6 +8308,50 @@ video {
   padding: 0.875rem;
 }
 
+.p-3xs {
+  padding: .125rem;
+}
+
+.p-xxs {
+  padding: .25rem;
+}
+
+.p-xs {
+  padding: .5rem;
+}
+
+.p-s {
+  padding: .75rem;
+}
+
+.p-m {
+  padding: 1rem;
+}
+
+.p-l {
+  padding: 1.5rem;
+}
+
+.p-xl {
+  padding: 2rem;
+}
+
+.p-xxl {
+  padding: 2.5rem;
+}
+
+.p-3xl {
+  padding: 3rem;
+}
+
+.p-4xl {
+  padding: 4rem;
+}
+
+.p-5xl {
+  padding: 8rem;
+}
+
 .py-0 {
   padding-top: 0px;
   padding-bottom: 0px;
@@ -7644,6 +8700,116 @@ video {
 .px-3\.5 {
   padding-left: 0.875rem;
   padding-right: 0.875rem;
+}
+
+.py-3xs {
+  padding-top: .125rem;
+  padding-bottom: .125rem;
+}
+
+.px-3xs {
+  padding-left: .125rem;
+  padding-right: .125rem;
+}
+
+.py-xxs {
+  padding-top: .25rem;
+  padding-bottom: .25rem;
+}
+
+.px-xxs {
+  padding-left: .25rem;
+  padding-right: .25rem;
+}
+
+.py-xs {
+  padding-top: .5rem;
+  padding-bottom: .5rem;
+}
+
+.px-xs {
+  padding-left: .5rem;
+  padding-right: .5rem;
+}
+
+.py-s {
+  padding-top: .75rem;
+  padding-bottom: .75rem;
+}
+
+.px-s {
+  padding-left: .75rem;
+  padding-right: .75rem;
+}
+
+.py-m {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.px-m {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.py-l {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.px-l {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.py-xl {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.px-xl {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.py-xxl {
+  padding-top: 2.5rem;
+  padding-bottom: 2.5rem;
+}
+
+.px-xxl {
+  padding-left: 2.5rem;
+  padding-right: 2.5rem;
+}
+
+.py-3xl {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.px-3xl {
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+.py-4xl {
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+}
+
+.px-4xl {
+  padding-left: 4rem;
+  padding-right: 4rem;
+}
+
+.py-5xl {
+  padding-top: 8rem;
+  padding-bottom: 8rem;
+}
+
+.px-5xl {
+  padding-left: 8rem;
+  padding-right: 8rem;
 }
 
 .pt-0 {
@@ -8204,6 +9370,182 @@ video {
 
 .pl-3\.5 {
   padding-left: 0.875rem;
+}
+
+.pt-3xs {
+  padding-top: .125rem;
+}
+
+.pr-3xs {
+  padding-right: .125rem;
+}
+
+.pb-3xs {
+  padding-bottom: .125rem;
+}
+
+.pl-3xs {
+  padding-left: .125rem;
+}
+
+.pt-xxs {
+  padding-top: .25rem;
+}
+
+.pr-xxs {
+  padding-right: .25rem;
+}
+
+.pb-xxs {
+  padding-bottom: .25rem;
+}
+
+.pl-xxs {
+  padding-left: .25rem;
+}
+
+.pt-xs {
+  padding-top: .5rem;
+}
+
+.pr-xs {
+  padding-right: .5rem;
+}
+
+.pb-xs {
+  padding-bottom: .5rem;
+}
+
+.pl-xs {
+  padding-left: .5rem;
+}
+
+.pt-s {
+  padding-top: .75rem;
+}
+
+.pr-s {
+  padding-right: .75rem;
+}
+
+.pb-s {
+  padding-bottom: .75rem;
+}
+
+.pl-s {
+  padding-left: .75rem;
+}
+
+.pt-m {
+  padding-top: 1rem;
+}
+
+.pr-m {
+  padding-right: 1rem;
+}
+
+.pb-m {
+  padding-bottom: 1rem;
+}
+
+.pl-m {
+  padding-left: 1rem;
+}
+
+.pt-l {
+  padding-top: 1.5rem;
+}
+
+.pr-l {
+  padding-right: 1.5rem;
+}
+
+.pb-l {
+  padding-bottom: 1.5rem;
+}
+
+.pl-l {
+  padding-left: 1.5rem;
+}
+
+.pt-xl {
+  padding-top: 2rem;
+}
+
+.pr-xl {
+  padding-right: 2rem;
+}
+
+.pb-xl {
+  padding-bottom: 2rem;
+}
+
+.pl-xl {
+  padding-left: 2rem;
+}
+
+.pt-xxl {
+  padding-top: 2.5rem;
+}
+
+.pr-xxl {
+  padding-right: 2.5rem;
+}
+
+.pb-xxl {
+  padding-bottom: 2.5rem;
+}
+
+.pl-xxl {
+  padding-left: 2.5rem;
+}
+
+.pt-3xl {
+  padding-top: 3rem;
+}
+
+.pr-3xl {
+  padding-right: 3rem;
+}
+
+.pb-3xl {
+  padding-bottom: 3rem;
+}
+
+.pl-3xl {
+  padding-left: 3rem;
+}
+
+.pt-4xl {
+  padding-top: 4rem;
+}
+
+.pr-4xl {
+  padding-right: 4rem;
+}
+
+.pb-4xl {
+  padding-bottom: 4rem;
+}
+
+.pl-4xl {
+  padding-left: 4rem;
+}
+
+.pt-5xl {
+  padding-top: 8rem;
+}
+
+.pr-5xl {
+  padding-right: 8rem;
+}
+
+.pb-5xl {
+  padding-bottom: 8rem;
+}
+
+.pl-5xl {
+  padding-left: 8rem;
 }
 
 .placeholder-primary::-moz-placeholder {
@@ -9087,6 +10429,83 @@ video {
   left: 0.875rem;
 }
 
+.inset-3xs {
+  top: .125rem;
+  right: .125rem;
+  bottom: .125rem;
+  left: .125rem;
+}
+
+.inset-xxs {
+  top: .25rem;
+  right: .25rem;
+  bottom: .25rem;
+  left: .25rem;
+}
+
+.inset-xs {
+  top: .5rem;
+  right: .5rem;
+  bottom: .5rem;
+  left: .5rem;
+}
+
+.inset-s {
+  top: .75rem;
+  right: .75rem;
+  bottom: .75rem;
+  left: .75rem;
+}
+
+.inset-m {
+  top: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+}
+
+.inset-l {
+  top: 1.5rem;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  left: 1.5rem;
+}
+
+.inset-xl {
+  top: 2rem;
+  right: 2rem;
+  bottom: 2rem;
+  left: 2rem;
+}
+
+.inset-xxl {
+  top: 2.5rem;
+  right: 2.5rem;
+  bottom: 2.5rem;
+  left: 2.5rem;
+}
+
+.inset-3xl {
+  top: 3rem;
+  right: 3rem;
+  bottom: 3rem;
+  left: 3rem;
+}
+
+.inset-4xl {
+  top: 4rem;
+  right: 4rem;
+  bottom: 4rem;
+  left: 4rem;
+}
+
+.inset-5xl {
+  top: 8rem;
+  right: 8rem;
+  bottom: 8rem;
+  left: 8rem;
+}
+
 .-inset-0 {
   top: 0px;
   right: 0px;
@@ -9330,6 +10749,83 @@ video {
   right: -0.875rem;
   bottom: -0.875rem;
   left: -0.875rem;
+}
+
+.-inset-3xs {
+  top: -0.125rem;
+  right: -0.125rem;
+  bottom: -0.125rem;
+  left: -0.125rem;
+}
+
+.-inset-xxs {
+  top: -0.25rem;
+  right: -0.25rem;
+  bottom: -0.25rem;
+  left: -0.25rem;
+}
+
+.-inset-xs {
+  top: -0.5rem;
+  right: -0.5rem;
+  bottom: -0.5rem;
+  left: -0.5rem;
+}
+
+.-inset-s {
+  top: -0.75rem;
+  right: -0.75rem;
+  bottom: -0.75rem;
+  left: -0.75rem;
+}
+
+.-inset-m {
+  top: -1rem;
+  right: -1rem;
+  bottom: -1rem;
+  left: -1rem;
+}
+
+.-inset-l {
+  top: -1.5rem;
+  right: -1.5rem;
+  bottom: -1.5rem;
+  left: -1.5rem;
+}
+
+.-inset-xl {
+  top: -2rem;
+  right: -2rem;
+  bottom: -2rem;
+  left: -2rem;
+}
+
+.-inset-xxl {
+  top: -2.5rem;
+  right: -2.5rem;
+  bottom: -2.5rem;
+  left: -2.5rem;
+}
+
+.-inset-3xl {
+  top: -3rem;
+  right: -3rem;
+  bottom: -3rem;
+  left: -3rem;
+}
+
+.-inset-4xl {
+  top: -4rem;
+  right: -4rem;
+  bottom: -4rem;
+  left: -4rem;
+}
+
+.-inset-5xl {
+  top: -8rem;
+  right: -8rem;
+  bottom: -8rem;
+  left: -8rem;
 }
 
 .inset-1\/2 {
@@ -9790,6 +11286,116 @@ video {
   left: 0.875rem;
 }
 
+.inset-y-3xs {
+  top: .125rem;
+  bottom: .125rem;
+}
+
+.inset-x-3xs {
+  right: .125rem;
+  left: .125rem;
+}
+
+.inset-y-xxs {
+  top: .25rem;
+  bottom: .25rem;
+}
+
+.inset-x-xxs {
+  right: .25rem;
+  left: .25rem;
+}
+
+.inset-y-xs {
+  top: .5rem;
+  bottom: .5rem;
+}
+
+.inset-x-xs {
+  right: .5rem;
+  left: .5rem;
+}
+
+.inset-y-s {
+  top: .75rem;
+  bottom: .75rem;
+}
+
+.inset-x-s {
+  right: .75rem;
+  left: .75rem;
+}
+
+.inset-y-m {
+  top: 1rem;
+  bottom: 1rem;
+}
+
+.inset-x-m {
+  right: 1rem;
+  left: 1rem;
+}
+
+.inset-y-l {
+  top: 1.5rem;
+  bottom: 1.5rem;
+}
+
+.inset-x-l {
+  right: 1.5rem;
+  left: 1.5rem;
+}
+
+.inset-y-xl {
+  top: 2rem;
+  bottom: 2rem;
+}
+
+.inset-x-xl {
+  right: 2rem;
+  left: 2rem;
+}
+
+.inset-y-xxl {
+  top: 2.5rem;
+  bottom: 2.5rem;
+}
+
+.inset-x-xxl {
+  right: 2.5rem;
+  left: 2.5rem;
+}
+
+.inset-y-3xl {
+  top: 3rem;
+  bottom: 3rem;
+}
+
+.inset-x-3xl {
+  right: 3rem;
+  left: 3rem;
+}
+
+.inset-y-4xl {
+  top: 4rem;
+  bottom: 4rem;
+}
+
+.inset-x-4xl {
+  right: 4rem;
+  left: 4rem;
+}
+
+.inset-y-5xl {
+  top: 8rem;
+  bottom: 8rem;
+}
+
+.inset-x-5xl {
+  right: 8rem;
+  left: 8rem;
+}
+
 .-inset-y-0 {
   top: 0px;
   bottom: 0px;
@@ -10138,6 +11744,116 @@ video {
 .-inset-x-3\.5 {
   right: -0.875rem;
   left: -0.875rem;
+}
+
+.-inset-y-3xs {
+  top: -0.125rem;
+  bottom: -0.125rem;
+}
+
+.-inset-x-3xs {
+  right: -0.125rem;
+  left: -0.125rem;
+}
+
+.-inset-y-xxs {
+  top: -0.25rem;
+  bottom: -0.25rem;
+}
+
+.-inset-x-xxs {
+  right: -0.25rem;
+  left: -0.25rem;
+}
+
+.-inset-y-xs {
+  top: -0.5rem;
+  bottom: -0.5rem;
+}
+
+.-inset-x-xs {
+  right: -0.5rem;
+  left: -0.5rem;
+}
+
+.-inset-y-s {
+  top: -0.75rem;
+  bottom: -0.75rem;
+}
+
+.-inset-x-s {
+  right: -0.75rem;
+  left: -0.75rem;
+}
+
+.-inset-y-m {
+  top: -1rem;
+  bottom: -1rem;
+}
+
+.-inset-x-m {
+  right: -1rem;
+  left: -1rem;
+}
+
+.-inset-y-l {
+  top: -1.5rem;
+  bottom: -1.5rem;
+}
+
+.-inset-x-l {
+  right: -1.5rem;
+  left: -1.5rem;
+}
+
+.-inset-y-xl {
+  top: -2rem;
+  bottom: -2rem;
+}
+
+.-inset-x-xl {
+  right: -2rem;
+  left: -2rem;
+}
+
+.-inset-y-xxl {
+  top: -2.5rem;
+  bottom: -2.5rem;
+}
+
+.-inset-x-xxl {
+  right: -2.5rem;
+  left: -2.5rem;
+}
+
+.-inset-y-3xl {
+  top: -3rem;
+  bottom: -3rem;
+}
+
+.-inset-x-3xl {
+  right: -3rem;
+  left: -3rem;
+}
+
+.-inset-y-4xl {
+  top: -4rem;
+  bottom: -4rem;
+}
+
+.-inset-x-4xl {
+  right: -4rem;
+  left: -4rem;
+}
+
+.-inset-y-5xl {
+  top: -8rem;
+  bottom: -8rem;
+}
+
+.-inset-x-5xl {
+  right: -8rem;
+  left: -8rem;
 }
 
 .inset-y-1\/2 {
@@ -10856,6 +12572,182 @@ video {
   left: 0.875rem;
 }
 
+.top-3xs {
+  top: .125rem;
+}
+
+.right-3xs {
+  right: .125rem;
+}
+
+.bottom-3xs {
+  bottom: .125rem;
+}
+
+.left-3xs {
+  left: .125rem;
+}
+
+.top-xxs {
+  top: .25rem;
+}
+
+.right-xxs {
+  right: .25rem;
+}
+
+.bottom-xxs {
+  bottom: .25rem;
+}
+
+.left-xxs {
+  left: .25rem;
+}
+
+.top-xs {
+  top: .5rem;
+}
+
+.right-xs {
+  right: .5rem;
+}
+
+.bottom-xs {
+  bottom: .5rem;
+}
+
+.left-xs {
+  left: .5rem;
+}
+
+.top-s {
+  top: .75rem;
+}
+
+.right-s {
+  right: .75rem;
+}
+
+.bottom-s {
+  bottom: .75rem;
+}
+
+.left-s {
+  left: .75rem;
+}
+
+.top-m {
+  top: 1rem;
+}
+
+.right-m {
+  right: 1rem;
+}
+
+.bottom-m {
+  bottom: 1rem;
+}
+
+.left-m {
+  left: 1rem;
+}
+
+.top-l {
+  top: 1.5rem;
+}
+
+.right-l {
+  right: 1.5rem;
+}
+
+.bottom-l {
+  bottom: 1.5rem;
+}
+
+.left-l {
+  left: 1.5rem;
+}
+
+.top-xl {
+  top: 2rem;
+}
+
+.right-xl {
+  right: 2rem;
+}
+
+.bottom-xl {
+  bottom: 2rem;
+}
+
+.left-xl {
+  left: 2rem;
+}
+
+.top-xxl {
+  top: 2.5rem;
+}
+
+.right-xxl {
+  right: 2.5rem;
+}
+
+.bottom-xxl {
+  bottom: 2.5rem;
+}
+
+.left-xxl {
+  left: 2.5rem;
+}
+
+.top-3xl {
+  top: 3rem;
+}
+
+.right-3xl {
+  right: 3rem;
+}
+
+.bottom-3xl {
+  bottom: 3rem;
+}
+
+.left-3xl {
+  left: 3rem;
+}
+
+.top-4xl {
+  top: 4rem;
+}
+
+.right-4xl {
+  right: 4rem;
+}
+
+.bottom-4xl {
+  bottom: 4rem;
+}
+
+.left-4xl {
+  left: 4rem;
+}
+
+.top-5xl {
+  top: 8rem;
+}
+
+.right-5xl {
+  right: 8rem;
+}
+
+.bottom-5xl {
+  bottom: 8rem;
+}
+
+.left-5xl {
+  left: 8rem;
+}
+
 .-top-0 {
   top: 0px;
 }
@@ -11414,6 +13306,182 @@ video {
 
 .-left-3\.5 {
   left: -0.875rem;
+}
+
+.-top-3xs {
+  top: -0.125rem;
+}
+
+.-right-3xs {
+  right: -0.125rem;
+}
+
+.-bottom-3xs {
+  bottom: -0.125rem;
+}
+
+.-left-3xs {
+  left: -0.125rem;
+}
+
+.-top-xxs {
+  top: -0.25rem;
+}
+
+.-right-xxs {
+  right: -0.25rem;
+}
+
+.-bottom-xxs {
+  bottom: -0.25rem;
+}
+
+.-left-xxs {
+  left: -0.25rem;
+}
+
+.-top-xs {
+  top: -0.5rem;
+}
+
+.-right-xs {
+  right: -0.5rem;
+}
+
+.-bottom-xs {
+  bottom: -0.5rem;
+}
+
+.-left-xs {
+  left: -0.5rem;
+}
+
+.-top-s {
+  top: -0.75rem;
+}
+
+.-right-s {
+  right: -0.75rem;
+}
+
+.-bottom-s {
+  bottom: -0.75rem;
+}
+
+.-left-s {
+  left: -0.75rem;
+}
+
+.-top-m {
+  top: -1rem;
+}
+
+.-right-m {
+  right: -1rem;
+}
+
+.-bottom-m {
+  bottom: -1rem;
+}
+
+.-left-m {
+  left: -1rem;
+}
+
+.-top-l {
+  top: -1.5rem;
+}
+
+.-right-l {
+  right: -1.5rem;
+}
+
+.-bottom-l {
+  bottom: -1.5rem;
+}
+
+.-left-l {
+  left: -1.5rem;
+}
+
+.-top-xl {
+  top: -2rem;
+}
+
+.-right-xl {
+  right: -2rem;
+}
+
+.-bottom-xl {
+  bottom: -2rem;
+}
+
+.-left-xl {
+  left: -2rem;
+}
+
+.-top-xxl {
+  top: -2.5rem;
+}
+
+.-right-xxl {
+  right: -2.5rem;
+}
+
+.-bottom-xxl {
+  bottom: -2.5rem;
+}
+
+.-left-xxl {
+  left: -2.5rem;
+}
+
+.-top-3xl {
+  top: -3rem;
+}
+
+.-right-3xl {
+  right: -3rem;
+}
+
+.-bottom-3xl {
+  bottom: -3rem;
+}
+
+.-left-3xl {
+  left: -3rem;
+}
+
+.-top-4xl {
+  top: -4rem;
+}
+
+.-right-4xl {
+  right: -4rem;
+}
+
+.-bottom-4xl {
+  bottom: -4rem;
+}
+
+.-left-4xl {
+  left: -4rem;
+}
+
+.-top-5xl {
+  top: -8rem;
+}
+
+.-right-5xl {
+  right: -8rem;
+}
+
+.-bottom-5xl {
+  bottom: -8rem;
+}
+
+.-left-5xl {
+  left: -8rem;
 }
 
 .top-1\/2 {
@@ -13302,6 +15370,50 @@ video {
   width: 0.875rem;
 }
 
+.w-3xs {
+  width: .125rem;
+}
+
+.w-xxs {
+  width: .25rem;
+}
+
+.w-xs {
+  width: .5rem;
+}
+
+.w-s {
+  width: .75rem;
+}
+
+.w-m {
+  width: 1rem;
+}
+
+.w-l {
+  width: 1.5rem;
+}
+
+.w-xl {
+  width: 2rem;
+}
+
+.w-xxl {
+  width: 2.5rem;
+}
+
+.w-3xl {
+  width: 3rem;
+}
+
+.w-4xl {
+  width: 4rem;
+}
+
+.w-5xl {
+  width: 8rem;
+}
+
 .w-1\/2 {
   width: 50%;
 }
@@ -13650,6 +15762,50 @@ video {
   gap: 0.875rem;
 }
 
+.gap-3xs {
+  gap: .125rem;
+}
+
+.gap-xxs {
+  gap: .25rem;
+}
+
+.gap-xs {
+  gap: .5rem;
+}
+
+.gap-s {
+  gap: .75rem;
+}
+
+.gap-m {
+  gap: 1rem;
+}
+
+.gap-l {
+  gap: 1.5rem;
+}
+
+.gap-xl {
+  gap: 2rem;
+}
+
+.gap-xxl {
+  gap: 2.5rem;
+}
+
+.gap-3xl {
+  gap: 3rem;
+}
+
+.gap-4xl {
+  gap: 4rem;
+}
+
+.gap-5xl {
+  gap: 8rem;
+}
+
 .gap-x-0 {
   -moz-column-gap: 0px;
        column-gap: 0px;
@@ -13825,6 +15981,61 @@ video {
        column-gap: 0.875rem;
 }
 
+.gap-x-3xs {
+  -moz-column-gap: .125rem;
+       column-gap: .125rem;
+}
+
+.gap-x-xxs {
+  -moz-column-gap: .25rem;
+       column-gap: .25rem;
+}
+
+.gap-x-xs {
+  -moz-column-gap: .5rem;
+       column-gap: .5rem;
+}
+
+.gap-x-s {
+  -moz-column-gap: .75rem;
+       column-gap: .75rem;
+}
+
+.gap-x-m {
+  -moz-column-gap: 1rem;
+       column-gap: 1rem;
+}
+
+.gap-x-l {
+  -moz-column-gap: 1.5rem;
+       column-gap: 1.5rem;
+}
+
+.gap-x-xl {
+  -moz-column-gap: 2rem;
+       column-gap: 2rem;
+}
+
+.gap-x-xxl {
+  -moz-column-gap: 2.5rem;
+       column-gap: 2.5rem;
+}
+
+.gap-x-3xl {
+  -moz-column-gap: 3rem;
+       column-gap: 3rem;
+}
+
+.gap-x-4xl {
+  -moz-column-gap: 4rem;
+       column-gap: 4rem;
+}
+
+.gap-x-5xl {
+  -moz-column-gap: 8rem;
+       column-gap: 8rem;
+}
+
 .gap-y-0 {
   row-gap: 0px;
 }
@@ -13963,6 +16174,50 @@ video {
 
 .gap-y-3\.5 {
   row-gap: 0.875rem;
+}
+
+.gap-y-3xs {
+  row-gap: .125rem;
+}
+
+.gap-y-xxs {
+  row-gap: .25rem;
+}
+
+.gap-y-xs {
+  row-gap: .5rem;
+}
+
+.gap-y-s {
+  row-gap: .75rem;
+}
+
+.gap-y-m {
+  row-gap: 1rem;
+}
+
+.gap-y-l {
+  row-gap: 1.5rem;
+}
+
+.gap-y-xl {
+  row-gap: 2rem;
+}
+
+.gap-y-xxl {
+  row-gap: 2.5rem;
+}
+
+.gap-y-3xl {
+  row-gap: 3rem;
+}
+
+.gap-y-4xl {
+  row-gap: 4rem;
+}
+
+.gap-y-5xl {
+  row-gap: 8rem;
 }
 
 .grid-flow-row {
@@ -15157,6 +17412,50 @@ video {
   --tw-translate-x: 0.875rem;
 }
 
+.translate-x-3xs {
+  --tw-translate-x: .125rem;
+}
+
+.translate-x-xxs {
+  --tw-translate-x: .25rem;
+}
+
+.translate-x-xs {
+  --tw-translate-x: .5rem;
+}
+
+.translate-x-s {
+  --tw-translate-x: .75rem;
+}
+
+.translate-x-m {
+  --tw-translate-x: 1rem;
+}
+
+.translate-x-l {
+  --tw-translate-x: 1.5rem;
+}
+
+.translate-x-xl {
+  --tw-translate-x: 2rem;
+}
+
+.translate-x-xxl {
+  --tw-translate-x: 2.5rem;
+}
+
+.translate-x-3xl {
+  --tw-translate-x: 3rem;
+}
+
+.translate-x-4xl {
+  --tw-translate-x: 4rem;
+}
+
+.translate-x-5xl {
+  --tw-translate-x: 8rem;
+}
+
 .-translate-x-0 {
   --tw-translate-x: 0px;
 }
@@ -15295,6 +17594,50 @@ video {
 
 .-translate-x-3\.5 {
   --tw-translate-x: -0.875rem;
+}
+
+.-translate-x-3xs {
+  --tw-translate-x: -0.125rem;
+}
+
+.-translate-x-xxs {
+  --tw-translate-x: -0.25rem;
+}
+
+.-translate-x-xs {
+  --tw-translate-x: -0.5rem;
+}
+
+.-translate-x-s {
+  --tw-translate-x: -0.75rem;
+}
+
+.-translate-x-m {
+  --tw-translate-x: -1rem;
+}
+
+.-translate-x-l {
+  --tw-translate-x: -1.5rem;
+}
+
+.-translate-x-xl {
+  --tw-translate-x: -2rem;
+}
+
+.-translate-x-xxl {
+  --tw-translate-x: -2.5rem;
+}
+
+.-translate-x-3xl {
+  --tw-translate-x: -3rem;
+}
+
+.-translate-x-4xl {
+  --tw-translate-x: -4rem;
+}
+
+.-translate-x-5xl {
+  --tw-translate-x: -8rem;
 }
 
 .translate-x-1\/2 {
@@ -15493,6 +17836,50 @@ video {
   --tw-translate-y: 0.875rem;
 }
 
+.translate-y-3xs {
+  --tw-translate-y: .125rem;
+}
+
+.translate-y-xxs {
+  --tw-translate-y: .25rem;
+}
+
+.translate-y-xs {
+  --tw-translate-y: .5rem;
+}
+
+.translate-y-s {
+  --tw-translate-y: .75rem;
+}
+
+.translate-y-m {
+  --tw-translate-y: 1rem;
+}
+
+.translate-y-l {
+  --tw-translate-y: 1.5rem;
+}
+
+.translate-y-xl {
+  --tw-translate-y: 2rem;
+}
+
+.translate-y-xxl {
+  --tw-translate-y: 2.5rem;
+}
+
+.translate-y-3xl {
+  --tw-translate-y: 3rem;
+}
+
+.translate-y-4xl {
+  --tw-translate-y: 4rem;
+}
+
+.translate-y-5xl {
+  --tw-translate-y: 8rem;
+}
+
 .-translate-y-0 {
   --tw-translate-y: 0px;
 }
@@ -15631,6 +18018,50 @@ video {
 
 .-translate-y-3\.5 {
   --tw-translate-y: -0.875rem;
+}
+
+.-translate-y-3xs {
+  --tw-translate-y: -0.125rem;
+}
+
+.-translate-y-xxs {
+  --tw-translate-y: -0.25rem;
+}
+
+.-translate-y-xs {
+  --tw-translate-y: -0.5rem;
+}
+
+.-translate-y-s {
+  --tw-translate-y: -0.75rem;
+}
+
+.-translate-y-m {
+  --tw-translate-y: -1rem;
+}
+
+.-translate-y-l {
+  --tw-translate-y: -1.5rem;
+}
+
+.-translate-y-xl {
+  --tw-translate-y: -2rem;
+}
+
+.-translate-y-xxl {
+  --tw-translate-y: -2.5rem;
+}
+
+.-translate-y-3xl {
+  --tw-translate-y: -3rem;
+}
+
+.-translate-y-4xl {
+  --tw-translate-y: -4rem;
+}
+
+.-translate-y-5xl {
+  --tw-translate-y: -8rem;
 }
 
 .translate-y-1\/2 {
@@ -15829,6 +18260,50 @@ video {
   --tw-translate-x: 0.875rem;
 }
 
+.hover\:translate-x-3xs:hover {
+  --tw-translate-x: .125rem;
+}
+
+.hover\:translate-x-xxs:hover {
+  --tw-translate-x: .25rem;
+}
+
+.hover\:translate-x-xs:hover {
+  --tw-translate-x: .5rem;
+}
+
+.hover\:translate-x-s:hover {
+  --tw-translate-x: .75rem;
+}
+
+.hover\:translate-x-m:hover {
+  --tw-translate-x: 1rem;
+}
+
+.hover\:translate-x-l:hover {
+  --tw-translate-x: 1.5rem;
+}
+
+.hover\:translate-x-xl:hover {
+  --tw-translate-x: 2rem;
+}
+
+.hover\:translate-x-xxl:hover {
+  --tw-translate-x: 2.5rem;
+}
+
+.hover\:translate-x-3xl:hover {
+  --tw-translate-x: 3rem;
+}
+
+.hover\:translate-x-4xl:hover {
+  --tw-translate-x: 4rem;
+}
+
+.hover\:translate-x-5xl:hover {
+  --tw-translate-x: 8rem;
+}
+
 .hover\:-translate-x-0:hover {
   --tw-translate-x: 0px;
 }
@@ -15967,6 +18442,50 @@ video {
 
 .hover\:-translate-x-3\.5:hover {
   --tw-translate-x: -0.875rem;
+}
+
+.hover\:-translate-x-3xs:hover {
+  --tw-translate-x: -0.125rem;
+}
+
+.hover\:-translate-x-xxs:hover {
+  --tw-translate-x: -0.25rem;
+}
+
+.hover\:-translate-x-xs:hover {
+  --tw-translate-x: -0.5rem;
+}
+
+.hover\:-translate-x-s:hover {
+  --tw-translate-x: -0.75rem;
+}
+
+.hover\:-translate-x-m:hover {
+  --tw-translate-x: -1rem;
+}
+
+.hover\:-translate-x-l:hover {
+  --tw-translate-x: -1.5rem;
+}
+
+.hover\:-translate-x-xl:hover {
+  --tw-translate-x: -2rem;
+}
+
+.hover\:-translate-x-xxl:hover {
+  --tw-translate-x: -2.5rem;
+}
+
+.hover\:-translate-x-3xl:hover {
+  --tw-translate-x: -3rem;
+}
+
+.hover\:-translate-x-4xl:hover {
+  --tw-translate-x: -4rem;
+}
+
+.hover\:-translate-x-5xl:hover {
+  --tw-translate-x: -8rem;
 }
 
 .hover\:translate-x-1\/2:hover {
@@ -16165,6 +18684,50 @@ video {
   --tw-translate-y: 0.875rem;
 }
 
+.hover\:translate-y-3xs:hover {
+  --tw-translate-y: .125rem;
+}
+
+.hover\:translate-y-xxs:hover {
+  --tw-translate-y: .25rem;
+}
+
+.hover\:translate-y-xs:hover {
+  --tw-translate-y: .5rem;
+}
+
+.hover\:translate-y-s:hover {
+  --tw-translate-y: .75rem;
+}
+
+.hover\:translate-y-m:hover {
+  --tw-translate-y: 1rem;
+}
+
+.hover\:translate-y-l:hover {
+  --tw-translate-y: 1.5rem;
+}
+
+.hover\:translate-y-xl:hover {
+  --tw-translate-y: 2rem;
+}
+
+.hover\:translate-y-xxl:hover {
+  --tw-translate-y: 2.5rem;
+}
+
+.hover\:translate-y-3xl:hover {
+  --tw-translate-y: 3rem;
+}
+
+.hover\:translate-y-4xl:hover {
+  --tw-translate-y: 4rem;
+}
+
+.hover\:translate-y-5xl:hover {
+  --tw-translate-y: 8rem;
+}
+
 .hover\:-translate-y-0:hover {
   --tw-translate-y: 0px;
 }
@@ -16303,6 +18866,50 @@ video {
 
 .hover\:-translate-y-3\.5:hover {
   --tw-translate-y: -0.875rem;
+}
+
+.hover\:-translate-y-3xs:hover {
+  --tw-translate-y: -0.125rem;
+}
+
+.hover\:-translate-y-xxs:hover {
+  --tw-translate-y: -0.25rem;
+}
+
+.hover\:-translate-y-xs:hover {
+  --tw-translate-y: -0.5rem;
+}
+
+.hover\:-translate-y-s:hover {
+  --tw-translate-y: -0.75rem;
+}
+
+.hover\:-translate-y-m:hover {
+  --tw-translate-y: -1rem;
+}
+
+.hover\:-translate-y-l:hover {
+  --tw-translate-y: -1.5rem;
+}
+
+.hover\:-translate-y-xl:hover {
+  --tw-translate-y: -2rem;
+}
+
+.hover\:-translate-y-xxl:hover {
+  --tw-translate-y: -2.5rem;
+}
+
+.hover\:-translate-y-3xl:hover {
+  --tw-translate-y: -3rem;
+}
+
+.hover\:-translate-y-4xl:hover {
+  --tw-translate-y: -4rem;
+}
+
+.hover\:-translate-y-5xl:hover {
+  --tw-translate-y: -8rem;
 }
 
 .hover\:translate-y-1\/2:hover {
@@ -16501,6 +19108,50 @@ video {
   --tw-translate-x: 0.875rem;
 }
 
+.focus\:translate-x-3xs:focus {
+  --tw-translate-x: .125rem;
+}
+
+.focus\:translate-x-xxs:focus {
+  --tw-translate-x: .25rem;
+}
+
+.focus\:translate-x-xs:focus {
+  --tw-translate-x: .5rem;
+}
+
+.focus\:translate-x-s:focus {
+  --tw-translate-x: .75rem;
+}
+
+.focus\:translate-x-m:focus {
+  --tw-translate-x: 1rem;
+}
+
+.focus\:translate-x-l:focus {
+  --tw-translate-x: 1.5rem;
+}
+
+.focus\:translate-x-xl:focus {
+  --tw-translate-x: 2rem;
+}
+
+.focus\:translate-x-xxl:focus {
+  --tw-translate-x: 2.5rem;
+}
+
+.focus\:translate-x-3xl:focus {
+  --tw-translate-x: 3rem;
+}
+
+.focus\:translate-x-4xl:focus {
+  --tw-translate-x: 4rem;
+}
+
+.focus\:translate-x-5xl:focus {
+  --tw-translate-x: 8rem;
+}
+
 .focus\:-translate-x-0:focus {
   --tw-translate-x: 0px;
 }
@@ -16639,6 +19290,50 @@ video {
 
 .focus\:-translate-x-3\.5:focus {
   --tw-translate-x: -0.875rem;
+}
+
+.focus\:-translate-x-3xs:focus {
+  --tw-translate-x: -0.125rem;
+}
+
+.focus\:-translate-x-xxs:focus {
+  --tw-translate-x: -0.25rem;
+}
+
+.focus\:-translate-x-xs:focus {
+  --tw-translate-x: -0.5rem;
+}
+
+.focus\:-translate-x-s:focus {
+  --tw-translate-x: -0.75rem;
+}
+
+.focus\:-translate-x-m:focus {
+  --tw-translate-x: -1rem;
+}
+
+.focus\:-translate-x-l:focus {
+  --tw-translate-x: -1.5rem;
+}
+
+.focus\:-translate-x-xl:focus {
+  --tw-translate-x: -2rem;
+}
+
+.focus\:-translate-x-xxl:focus {
+  --tw-translate-x: -2.5rem;
+}
+
+.focus\:-translate-x-3xl:focus {
+  --tw-translate-x: -3rem;
+}
+
+.focus\:-translate-x-4xl:focus {
+  --tw-translate-x: -4rem;
+}
+
+.focus\:-translate-x-5xl:focus {
+  --tw-translate-x: -8rem;
 }
 
 .focus\:translate-x-1\/2:focus {
@@ -16837,6 +19532,50 @@ video {
   --tw-translate-y: 0.875rem;
 }
 
+.focus\:translate-y-3xs:focus {
+  --tw-translate-y: .125rem;
+}
+
+.focus\:translate-y-xxs:focus {
+  --tw-translate-y: .25rem;
+}
+
+.focus\:translate-y-xs:focus {
+  --tw-translate-y: .5rem;
+}
+
+.focus\:translate-y-s:focus {
+  --tw-translate-y: .75rem;
+}
+
+.focus\:translate-y-m:focus {
+  --tw-translate-y: 1rem;
+}
+
+.focus\:translate-y-l:focus {
+  --tw-translate-y: 1.5rem;
+}
+
+.focus\:translate-y-xl:focus {
+  --tw-translate-y: 2rem;
+}
+
+.focus\:translate-y-xxl:focus {
+  --tw-translate-y: 2.5rem;
+}
+
+.focus\:translate-y-3xl:focus {
+  --tw-translate-y: 3rem;
+}
+
+.focus\:translate-y-4xl:focus {
+  --tw-translate-y: 4rem;
+}
+
+.focus\:translate-y-5xl:focus {
+  --tw-translate-y: 8rem;
+}
+
 .focus\:-translate-y-0:focus {
   --tw-translate-y: 0px;
 }
@@ -16975,6 +19714,50 @@ video {
 
 .focus\:-translate-y-3\.5:focus {
   --tw-translate-y: -0.875rem;
+}
+
+.focus\:-translate-y-3xs:focus {
+  --tw-translate-y: -0.125rem;
+}
+
+.focus\:-translate-y-xxs:focus {
+  --tw-translate-y: -0.25rem;
+}
+
+.focus\:-translate-y-xs:focus {
+  --tw-translate-y: -0.5rem;
+}
+
+.focus\:-translate-y-s:focus {
+  --tw-translate-y: -0.75rem;
+}
+
+.focus\:-translate-y-m:focus {
+  --tw-translate-y: -1rem;
+}
+
+.focus\:-translate-y-l:focus {
+  --tw-translate-y: -1.5rem;
+}
+
+.focus\:-translate-y-xl:focus {
+  --tw-translate-y: -2rem;
+}
+
+.focus\:-translate-y-xxl:focus {
+  --tw-translate-y: -2.5rem;
+}
+
+.focus\:-translate-y-3xl:focus {
+  --tw-translate-y: -3rem;
+}
+
+.focus\:-translate-y-4xl:focus {
+  --tw-translate-y: -4rem;
+}
+
+.focus\:-translate-y-5xl:focus {
+  --tw-translate-y: -8rem;
 }
 
 .focus\:translate-y-1\/2:focus {
@@ -17963,6 +20746,138 @@ video {
     margin-left: calc(0.875rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
+  .sm\:space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.125rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.125rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.125rem * var(--tw-space-x-reverse));
+    margin-left: calc(.125rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.25rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.25rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-y-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.5rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-y-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.75rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.75rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-y-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1rem * var(--tw-space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-y-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-y-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2rem * var(--tw-space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(2.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(2.5rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(3rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(3rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(3rem * var(--tw-space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(4rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(4rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(4rem * var(--tw-space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(8rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(8rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(8rem * var(--tw-space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
   .sm\:-space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
@@ -18381,6 +21296,138 @@ video {
     --tw-space-x-reverse: 0;
     margin-right: calc(-0.875rem * var(--tw-space-x-reverse));
     margin-left: calc(-0.875rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.125rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.125rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.125rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.25rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.25rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.5rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.75rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.75rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-1rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-1rem * var(--tw-space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-1.5rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-2rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-2rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-2rem * var(--tw-space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-2.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-2.5rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-3rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-3rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-3rem * var(--tw-space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-4rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-4rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-4rem * var(--tw-space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:-space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-8rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-8rem * var(--tw-space-y-reverse));
+  }
+
+  .sm\:-space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-8rem * var(--tw-space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .sm\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -21039,6 +24086,50 @@ video {
     height: 0.875rem;
   }
 
+  .sm\:h-3xs {
+    height: .125rem;
+  }
+
+  .sm\:h-xxs {
+    height: .25rem;
+  }
+
+  .sm\:h-xs {
+    height: .5rem;
+  }
+
+  .sm\:h-s {
+    height: .75rem;
+  }
+
+  .sm\:h-m {
+    height: 1rem;
+  }
+
+  .sm\:h-l {
+    height: 1.5rem;
+  }
+
+  .sm\:h-xl {
+    height: 2rem;
+  }
+
+  .sm\:h-xxl {
+    height: 2.5rem;
+  }
+
+  .sm\:h-3xl {
+    height: 3rem;
+  }
+
+  .sm\:h-4xl {
+    height: 4rem;
+  }
+
+  .sm\:h-5xl {
+    height: 8rem;
+  }
+
   .sm\:h-1\/2 {
     height: 50%;
   }
@@ -21355,6 +24446,50 @@ video {
     margin: 0.875rem;
   }
 
+  .sm\:m-3xs {
+    margin: .125rem;
+  }
+
+  .sm\:m-xxs {
+    margin: .25rem;
+  }
+
+  .sm\:m-xs {
+    margin: .5rem;
+  }
+
+  .sm\:m-s {
+    margin: .75rem;
+  }
+
+  .sm\:m-m {
+    margin: 1rem;
+  }
+
+  .sm\:m-l {
+    margin: 1.5rem;
+  }
+
+  .sm\:m-xl {
+    margin: 2rem;
+  }
+
+  .sm\:m-xxl {
+    margin: 2.5rem;
+  }
+
+  .sm\:m-3xl {
+    margin: 3rem;
+  }
+
+  .sm\:m-4xl {
+    margin: 4rem;
+  }
+
+  .sm\:m-5xl {
+    margin: 8rem;
+  }
+
   .sm\:-m-0 {
     margin: 0px;
   }
@@ -21493,6 +24628,50 @@ video {
 
   .sm\:-m-3\.5 {
     margin: -0.875rem;
+  }
+
+  .sm\:-m-3xs {
+    margin: -0.125rem;
+  }
+
+  .sm\:-m-xxs {
+    margin: -0.25rem;
+  }
+
+  .sm\:-m-xs {
+    margin: -0.5rem;
+  }
+
+  .sm\:-m-s {
+    margin: -0.75rem;
+  }
+
+  .sm\:-m-m {
+    margin: -1rem;
+  }
+
+  .sm\:-m-l {
+    margin: -1.5rem;
+  }
+
+  .sm\:-m-xl {
+    margin: -2rem;
+  }
+
+  .sm\:-m-xxl {
+    margin: -2.5rem;
+  }
+
+  .sm\:-m-3xl {
+    margin: -3rem;
+  }
+
+  .sm\:-m-4xl {
+    margin: -4rem;
+  }
+
+  .sm\:-m-5xl {
+    margin: -8rem;
   }
 
   .sm\:my-0 {
@@ -21855,6 +25034,116 @@ video {
     margin-right: 0.875rem;
   }
 
+  .sm\:my-3xs {
+    margin-top: .125rem;
+    margin-bottom: .125rem;
+  }
+
+  .sm\:mx-3xs {
+    margin-left: .125rem;
+    margin-right: .125rem;
+  }
+
+  .sm\:my-xxs {
+    margin-top: .25rem;
+    margin-bottom: .25rem;
+  }
+
+  .sm\:mx-xxs {
+    margin-left: .25rem;
+    margin-right: .25rem;
+  }
+
+  .sm\:my-xs {
+    margin-top: .5rem;
+    margin-bottom: .5rem;
+  }
+
+  .sm\:mx-xs {
+    margin-left: .5rem;
+    margin-right: .5rem;
+  }
+
+  .sm\:my-s {
+    margin-top: .75rem;
+    margin-bottom: .75rem;
+  }
+
+  .sm\:mx-s {
+    margin-left: .75rem;
+    margin-right: .75rem;
+  }
+
+  .sm\:my-m {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .sm\:mx-m {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+
+  .sm\:my-l {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .sm\:mx-l {
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+
+  .sm\:my-xl {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .sm\:mx-xl {
+    margin-left: 2rem;
+    margin-right: 2rem;
+  }
+
+  .sm\:my-xxl {
+    margin-top: 2.5rem;
+    margin-bottom: 2.5rem;
+  }
+
+  .sm\:mx-xxl {
+    margin-left: 2.5rem;
+    margin-right: 2.5rem;
+  }
+
+  .sm\:my-3xl {
+    margin-top: 3rem;
+    margin-bottom: 3rem;
+  }
+
+  .sm\:mx-3xl {
+    margin-left: 3rem;
+    margin-right: 3rem;
+  }
+
+  .sm\:my-4xl {
+    margin-top: 4rem;
+    margin-bottom: 4rem;
+  }
+
+  .sm\:mx-4xl {
+    margin-left: 4rem;
+    margin-right: 4rem;
+  }
+
+  .sm\:my-5xl {
+    margin-top: 8rem;
+    margin-bottom: 8rem;
+  }
+
+  .sm\:mx-5xl {
+    margin-left: 8rem;
+    margin-right: 8rem;
+  }
+
   .sm\:-my-0 {
     margin-top: 0px;
     margin-bottom: 0px;
@@ -22203,6 +25492,116 @@ video {
   .sm\:-mx-3\.5 {
     margin-left: -0.875rem;
     margin-right: -0.875rem;
+  }
+
+  .sm\:-my-3xs {
+    margin-top: -0.125rem;
+    margin-bottom: -0.125rem;
+  }
+
+  .sm\:-mx-3xs {
+    margin-left: -0.125rem;
+    margin-right: -0.125rem;
+  }
+
+  .sm\:-my-xxs {
+    margin-top: -0.25rem;
+    margin-bottom: -0.25rem;
+  }
+
+  .sm\:-mx-xxs {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+  }
+
+  .sm\:-my-xs {
+    margin-top: -0.5rem;
+    margin-bottom: -0.5rem;
+  }
+
+  .sm\:-mx-xs {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+  }
+
+  .sm\:-my-s {
+    margin-top: -0.75rem;
+    margin-bottom: -0.75rem;
+  }
+
+  .sm\:-mx-s {
+    margin-left: -0.75rem;
+    margin-right: -0.75rem;
+  }
+
+  .sm\:-my-m {
+    margin-top: -1rem;
+    margin-bottom: -1rem;
+  }
+
+  .sm\:-mx-m {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+
+  .sm\:-my-l {
+    margin-top: -1.5rem;
+    margin-bottom: -1.5rem;
+  }
+
+  .sm\:-mx-l {
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+  }
+
+  .sm\:-my-xl {
+    margin-top: -2rem;
+    margin-bottom: -2rem;
+  }
+
+  .sm\:-mx-xl {
+    margin-left: -2rem;
+    margin-right: -2rem;
+  }
+
+  .sm\:-my-xxl {
+    margin-top: -2.5rem;
+    margin-bottom: -2.5rem;
+  }
+
+  .sm\:-mx-xxl {
+    margin-left: -2.5rem;
+    margin-right: -2.5rem;
+  }
+
+  .sm\:-my-3xl {
+    margin-top: -3rem;
+    margin-bottom: -3rem;
+  }
+
+  .sm\:-mx-3xl {
+    margin-left: -3rem;
+    margin-right: -3rem;
+  }
+
+  .sm\:-my-4xl {
+    margin-top: -4rem;
+    margin-bottom: -4rem;
+  }
+
+  .sm\:-mx-4xl {
+    margin-left: -4rem;
+    margin-right: -4rem;
+  }
+
+  .sm\:-my-5xl {
+    margin-top: -8rem;
+    margin-bottom: -8rem;
+  }
+
+  .sm\:-mx-5xl {
+    margin-left: -8rem;
+    margin-right: -8rem;
   }
 
   .sm\:mt-0 {
@@ -22781,6 +26180,182 @@ video {
     margin-left: 0.875rem;
   }
 
+  .sm\:mt-3xs {
+    margin-top: .125rem;
+  }
+
+  .sm\:mr-3xs {
+    margin-right: .125rem;
+  }
+
+  .sm\:mb-3xs {
+    margin-bottom: .125rem;
+  }
+
+  .sm\:ml-3xs {
+    margin-left: .125rem;
+  }
+
+  .sm\:mt-xxs {
+    margin-top: .25rem;
+  }
+
+  .sm\:mr-xxs {
+    margin-right: .25rem;
+  }
+
+  .sm\:mb-xxs {
+    margin-bottom: .25rem;
+  }
+
+  .sm\:ml-xxs {
+    margin-left: .25rem;
+  }
+
+  .sm\:mt-xs {
+    margin-top: .5rem;
+  }
+
+  .sm\:mr-xs {
+    margin-right: .5rem;
+  }
+
+  .sm\:mb-xs {
+    margin-bottom: .5rem;
+  }
+
+  .sm\:ml-xs {
+    margin-left: .5rem;
+  }
+
+  .sm\:mt-s {
+    margin-top: .75rem;
+  }
+
+  .sm\:mr-s {
+    margin-right: .75rem;
+  }
+
+  .sm\:mb-s {
+    margin-bottom: .75rem;
+  }
+
+  .sm\:ml-s {
+    margin-left: .75rem;
+  }
+
+  .sm\:mt-m {
+    margin-top: 1rem;
+  }
+
+  .sm\:mr-m {
+    margin-right: 1rem;
+  }
+
+  .sm\:mb-m {
+    margin-bottom: 1rem;
+  }
+
+  .sm\:ml-m {
+    margin-left: 1rem;
+  }
+
+  .sm\:mt-l {
+    margin-top: 1.5rem;
+  }
+
+  .sm\:mr-l {
+    margin-right: 1.5rem;
+  }
+
+  .sm\:mb-l {
+    margin-bottom: 1.5rem;
+  }
+
+  .sm\:ml-l {
+    margin-left: 1.5rem;
+  }
+
+  .sm\:mt-xl {
+    margin-top: 2rem;
+  }
+
+  .sm\:mr-xl {
+    margin-right: 2rem;
+  }
+
+  .sm\:mb-xl {
+    margin-bottom: 2rem;
+  }
+
+  .sm\:ml-xl {
+    margin-left: 2rem;
+  }
+
+  .sm\:mt-xxl {
+    margin-top: 2.5rem;
+  }
+
+  .sm\:mr-xxl {
+    margin-right: 2.5rem;
+  }
+
+  .sm\:mb-xxl {
+    margin-bottom: 2.5rem;
+  }
+
+  .sm\:ml-xxl {
+    margin-left: 2.5rem;
+  }
+
+  .sm\:mt-3xl {
+    margin-top: 3rem;
+  }
+
+  .sm\:mr-3xl {
+    margin-right: 3rem;
+  }
+
+  .sm\:mb-3xl {
+    margin-bottom: 3rem;
+  }
+
+  .sm\:ml-3xl {
+    margin-left: 3rem;
+  }
+
+  .sm\:mt-4xl {
+    margin-top: 4rem;
+  }
+
+  .sm\:mr-4xl {
+    margin-right: 4rem;
+  }
+
+  .sm\:mb-4xl {
+    margin-bottom: 4rem;
+  }
+
+  .sm\:ml-4xl {
+    margin-left: 4rem;
+  }
+
+  .sm\:mt-5xl {
+    margin-top: 8rem;
+  }
+
+  .sm\:mr-5xl {
+    margin-right: 8rem;
+  }
+
+  .sm\:mb-5xl {
+    margin-bottom: 8rem;
+  }
+
+  .sm\:ml-5xl {
+    margin-left: 8rem;
+  }
+
   .sm\:-mt-0 {
     margin-top: 0px;
   }
@@ -23341,6 +26916,182 @@ video {
     margin-left: -0.875rem;
   }
 
+  .sm\:-mt-3xs {
+    margin-top: -0.125rem;
+  }
+
+  .sm\:-mr-3xs {
+    margin-right: -0.125rem;
+  }
+
+  .sm\:-mb-3xs {
+    margin-bottom: -0.125rem;
+  }
+
+  .sm\:-ml-3xs {
+    margin-left: -0.125rem;
+  }
+
+  .sm\:-mt-xxs {
+    margin-top: -0.25rem;
+  }
+
+  .sm\:-mr-xxs {
+    margin-right: -0.25rem;
+  }
+
+  .sm\:-mb-xxs {
+    margin-bottom: -0.25rem;
+  }
+
+  .sm\:-ml-xxs {
+    margin-left: -0.25rem;
+  }
+
+  .sm\:-mt-xs {
+    margin-top: -0.5rem;
+  }
+
+  .sm\:-mr-xs {
+    margin-right: -0.5rem;
+  }
+
+  .sm\:-mb-xs {
+    margin-bottom: -0.5rem;
+  }
+
+  .sm\:-ml-xs {
+    margin-left: -0.5rem;
+  }
+
+  .sm\:-mt-s {
+    margin-top: -0.75rem;
+  }
+
+  .sm\:-mr-s {
+    margin-right: -0.75rem;
+  }
+
+  .sm\:-mb-s {
+    margin-bottom: -0.75rem;
+  }
+
+  .sm\:-ml-s {
+    margin-left: -0.75rem;
+  }
+
+  .sm\:-mt-m {
+    margin-top: -1rem;
+  }
+
+  .sm\:-mr-m {
+    margin-right: -1rem;
+  }
+
+  .sm\:-mb-m {
+    margin-bottom: -1rem;
+  }
+
+  .sm\:-ml-m {
+    margin-left: -1rem;
+  }
+
+  .sm\:-mt-l {
+    margin-top: -1.5rem;
+  }
+
+  .sm\:-mr-l {
+    margin-right: -1.5rem;
+  }
+
+  .sm\:-mb-l {
+    margin-bottom: -1.5rem;
+  }
+
+  .sm\:-ml-l {
+    margin-left: -1.5rem;
+  }
+
+  .sm\:-mt-xl {
+    margin-top: -2rem;
+  }
+
+  .sm\:-mr-xl {
+    margin-right: -2rem;
+  }
+
+  .sm\:-mb-xl {
+    margin-bottom: -2rem;
+  }
+
+  .sm\:-ml-xl {
+    margin-left: -2rem;
+  }
+
+  .sm\:-mt-xxl {
+    margin-top: -2.5rem;
+  }
+
+  .sm\:-mr-xxl {
+    margin-right: -2.5rem;
+  }
+
+  .sm\:-mb-xxl {
+    margin-bottom: -2.5rem;
+  }
+
+  .sm\:-ml-xxl {
+    margin-left: -2.5rem;
+  }
+
+  .sm\:-mt-3xl {
+    margin-top: -3rem;
+  }
+
+  .sm\:-mr-3xl {
+    margin-right: -3rem;
+  }
+
+  .sm\:-mb-3xl {
+    margin-bottom: -3rem;
+  }
+
+  .sm\:-ml-3xl {
+    margin-left: -3rem;
+  }
+
+  .sm\:-mt-4xl {
+    margin-top: -4rem;
+  }
+
+  .sm\:-mr-4xl {
+    margin-right: -4rem;
+  }
+
+  .sm\:-mb-4xl {
+    margin-bottom: -4rem;
+  }
+
+  .sm\:-ml-4xl {
+    margin-left: -4rem;
+  }
+
+  .sm\:-mt-5xl {
+    margin-top: -8rem;
+  }
+
+  .sm\:-mr-5xl {
+    margin-right: -8rem;
+  }
+
+  .sm\:-mb-5xl {
+    margin-bottom: -8rem;
+  }
+
+  .sm\:-ml-5xl {
+    margin-left: -8rem;
+  }
+
   .sm\:max-h-0 {
     max-height: 0px;
   }
@@ -23479,6 +27230,50 @@ video {
 
   .sm\:max-h-3\.5 {
     max-height: 0.875rem;
+  }
+
+  .sm\:max-h-3xs {
+    max-height: .125rem;
+  }
+
+  .sm\:max-h-xxs {
+    max-height: .25rem;
+  }
+
+  .sm\:max-h-xs {
+    max-height: .5rem;
+  }
+
+  .sm\:max-h-s {
+    max-height: .75rem;
+  }
+
+  .sm\:max-h-m {
+    max-height: 1rem;
+  }
+
+  .sm\:max-h-l {
+    max-height: 1.5rem;
+  }
+
+  .sm\:max-h-xl {
+    max-height: 2rem;
+  }
+
+  .sm\:max-h-xxl {
+    max-height: 2.5rem;
+  }
+
+  .sm\:max-h-3xl {
+    max-height: 3rem;
+  }
+
+  .sm\:max-h-4xl {
+    max-height: 4rem;
+  }
+
+  .sm\:max-h-5xl {
+    max-height: 8rem;
   }
 
   .sm\:max-h-full {
@@ -24255,6 +28050,50 @@ video {
     padding: 0.875rem;
   }
 
+  .sm\:p-3xs {
+    padding: .125rem;
+  }
+
+  .sm\:p-xxs {
+    padding: .25rem;
+  }
+
+  .sm\:p-xs {
+    padding: .5rem;
+  }
+
+  .sm\:p-s {
+    padding: .75rem;
+  }
+
+  .sm\:p-m {
+    padding: 1rem;
+  }
+
+  .sm\:p-l {
+    padding: 1.5rem;
+  }
+
+  .sm\:p-xl {
+    padding: 2rem;
+  }
+
+  .sm\:p-xxl {
+    padding: 2.5rem;
+  }
+
+  .sm\:p-3xl {
+    padding: 3rem;
+  }
+
+  .sm\:p-4xl {
+    padding: 4rem;
+  }
+
+  .sm\:p-5xl {
+    padding: 8rem;
+  }
+
   .sm\:py-0 {
     padding-top: 0px;
     padding-bottom: 0px;
@@ -24603,6 +28442,116 @@ video {
   .sm\:px-3\.5 {
     padding-left: 0.875rem;
     padding-right: 0.875rem;
+  }
+
+  .sm\:py-3xs {
+    padding-top: .125rem;
+    padding-bottom: .125rem;
+  }
+
+  .sm\:px-3xs {
+    padding-left: .125rem;
+    padding-right: .125rem;
+  }
+
+  .sm\:py-xxs {
+    padding-top: .25rem;
+    padding-bottom: .25rem;
+  }
+
+  .sm\:px-xxs {
+    padding-left: .25rem;
+    padding-right: .25rem;
+  }
+
+  .sm\:py-xs {
+    padding-top: .5rem;
+    padding-bottom: .5rem;
+  }
+
+  .sm\:px-xs {
+    padding-left: .5rem;
+    padding-right: .5rem;
+  }
+
+  .sm\:py-s {
+    padding-top: .75rem;
+    padding-bottom: .75rem;
+  }
+
+  .sm\:px-s {
+    padding-left: .75rem;
+    padding-right: .75rem;
+  }
+
+  .sm\:py-m {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .sm\:px-m {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .sm\:py-l {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .sm\:px-l {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .sm\:py-xl {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+
+  .sm\:px-xl {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
+  .sm\:py-xxl {
+    padding-top: 2.5rem;
+    padding-bottom: 2.5rem;
+  }
+
+  .sm\:px-xxl {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+  }
+
+  .sm\:py-3xl {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+
+  .sm\:px-3xl {
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
+
+  .sm\:py-4xl {
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+  }
+
+  .sm\:px-4xl {
+    padding-left: 4rem;
+    padding-right: 4rem;
+  }
+
+  .sm\:py-5xl {
+    padding-top: 8rem;
+    padding-bottom: 8rem;
+  }
+
+  .sm\:px-5xl {
+    padding-left: 8rem;
+    padding-right: 8rem;
   }
 
   .sm\:pt-0 {
@@ -25163,6 +29112,182 @@ video {
 
   .sm\:pl-3\.5 {
     padding-left: 0.875rem;
+  }
+
+  .sm\:pt-3xs {
+    padding-top: .125rem;
+  }
+
+  .sm\:pr-3xs {
+    padding-right: .125rem;
+  }
+
+  .sm\:pb-3xs {
+    padding-bottom: .125rem;
+  }
+
+  .sm\:pl-3xs {
+    padding-left: .125rem;
+  }
+
+  .sm\:pt-xxs {
+    padding-top: .25rem;
+  }
+
+  .sm\:pr-xxs {
+    padding-right: .25rem;
+  }
+
+  .sm\:pb-xxs {
+    padding-bottom: .25rem;
+  }
+
+  .sm\:pl-xxs {
+    padding-left: .25rem;
+  }
+
+  .sm\:pt-xs {
+    padding-top: .5rem;
+  }
+
+  .sm\:pr-xs {
+    padding-right: .5rem;
+  }
+
+  .sm\:pb-xs {
+    padding-bottom: .5rem;
+  }
+
+  .sm\:pl-xs {
+    padding-left: .5rem;
+  }
+
+  .sm\:pt-s {
+    padding-top: .75rem;
+  }
+
+  .sm\:pr-s {
+    padding-right: .75rem;
+  }
+
+  .sm\:pb-s {
+    padding-bottom: .75rem;
+  }
+
+  .sm\:pl-s {
+    padding-left: .75rem;
+  }
+
+  .sm\:pt-m {
+    padding-top: 1rem;
+  }
+
+  .sm\:pr-m {
+    padding-right: 1rem;
+  }
+
+  .sm\:pb-m {
+    padding-bottom: 1rem;
+  }
+
+  .sm\:pl-m {
+    padding-left: 1rem;
+  }
+
+  .sm\:pt-l {
+    padding-top: 1.5rem;
+  }
+
+  .sm\:pr-l {
+    padding-right: 1.5rem;
+  }
+
+  .sm\:pb-l {
+    padding-bottom: 1.5rem;
+  }
+
+  .sm\:pl-l {
+    padding-left: 1.5rem;
+  }
+
+  .sm\:pt-xl {
+    padding-top: 2rem;
+  }
+
+  .sm\:pr-xl {
+    padding-right: 2rem;
+  }
+
+  .sm\:pb-xl {
+    padding-bottom: 2rem;
+  }
+
+  .sm\:pl-xl {
+    padding-left: 2rem;
+  }
+
+  .sm\:pt-xxl {
+    padding-top: 2.5rem;
+  }
+
+  .sm\:pr-xxl {
+    padding-right: 2.5rem;
+  }
+
+  .sm\:pb-xxl {
+    padding-bottom: 2.5rem;
+  }
+
+  .sm\:pl-xxl {
+    padding-left: 2.5rem;
+  }
+
+  .sm\:pt-3xl {
+    padding-top: 3rem;
+  }
+
+  .sm\:pr-3xl {
+    padding-right: 3rem;
+  }
+
+  .sm\:pb-3xl {
+    padding-bottom: 3rem;
+  }
+
+  .sm\:pl-3xl {
+    padding-left: 3rem;
+  }
+
+  .sm\:pt-4xl {
+    padding-top: 4rem;
+  }
+
+  .sm\:pr-4xl {
+    padding-right: 4rem;
+  }
+
+  .sm\:pb-4xl {
+    padding-bottom: 4rem;
+  }
+
+  .sm\:pl-4xl {
+    padding-left: 4rem;
+  }
+
+  .sm\:pt-5xl {
+    padding-top: 8rem;
+  }
+
+  .sm\:pr-5xl {
+    padding-right: 8rem;
+  }
+
+  .sm\:pb-5xl {
+    padding-bottom: 8rem;
+  }
+
+  .sm\:pl-5xl {
+    padding-left: 8rem;
   }
 
   .sm\:placeholder-primary::-moz-placeholder {
@@ -26046,6 +30171,83 @@ video {
     left: 0.875rem;
   }
 
+  .sm\:inset-3xs {
+    top: .125rem;
+    right: .125rem;
+    bottom: .125rem;
+    left: .125rem;
+  }
+
+  .sm\:inset-xxs {
+    top: .25rem;
+    right: .25rem;
+    bottom: .25rem;
+    left: .25rem;
+  }
+
+  .sm\:inset-xs {
+    top: .5rem;
+    right: .5rem;
+    bottom: .5rem;
+    left: .5rem;
+  }
+
+  .sm\:inset-s {
+    top: .75rem;
+    right: .75rem;
+    bottom: .75rem;
+    left: .75rem;
+  }
+
+  .sm\:inset-m {
+    top: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    left: 1rem;
+  }
+
+  .sm\:inset-l {
+    top: 1.5rem;
+    right: 1.5rem;
+    bottom: 1.5rem;
+    left: 1.5rem;
+  }
+
+  .sm\:inset-xl {
+    top: 2rem;
+    right: 2rem;
+    bottom: 2rem;
+    left: 2rem;
+  }
+
+  .sm\:inset-xxl {
+    top: 2.5rem;
+    right: 2.5rem;
+    bottom: 2.5rem;
+    left: 2.5rem;
+  }
+
+  .sm\:inset-3xl {
+    top: 3rem;
+    right: 3rem;
+    bottom: 3rem;
+    left: 3rem;
+  }
+
+  .sm\:inset-4xl {
+    top: 4rem;
+    right: 4rem;
+    bottom: 4rem;
+    left: 4rem;
+  }
+
+  .sm\:inset-5xl {
+    top: 8rem;
+    right: 8rem;
+    bottom: 8rem;
+    left: 8rem;
+  }
+
   .sm\:-inset-0 {
     top: 0px;
     right: 0px;
@@ -26289,6 +30491,83 @@ video {
     right: -0.875rem;
     bottom: -0.875rem;
     left: -0.875rem;
+  }
+
+  .sm\:-inset-3xs {
+    top: -0.125rem;
+    right: -0.125rem;
+    bottom: -0.125rem;
+    left: -0.125rem;
+  }
+
+  .sm\:-inset-xxs {
+    top: -0.25rem;
+    right: -0.25rem;
+    bottom: -0.25rem;
+    left: -0.25rem;
+  }
+
+  .sm\:-inset-xs {
+    top: -0.5rem;
+    right: -0.5rem;
+    bottom: -0.5rem;
+    left: -0.5rem;
+  }
+
+  .sm\:-inset-s {
+    top: -0.75rem;
+    right: -0.75rem;
+    bottom: -0.75rem;
+    left: -0.75rem;
+  }
+
+  .sm\:-inset-m {
+    top: -1rem;
+    right: -1rem;
+    bottom: -1rem;
+    left: -1rem;
+  }
+
+  .sm\:-inset-l {
+    top: -1.5rem;
+    right: -1.5rem;
+    bottom: -1.5rem;
+    left: -1.5rem;
+  }
+
+  .sm\:-inset-xl {
+    top: -2rem;
+    right: -2rem;
+    bottom: -2rem;
+    left: -2rem;
+  }
+
+  .sm\:-inset-xxl {
+    top: -2.5rem;
+    right: -2.5rem;
+    bottom: -2.5rem;
+    left: -2.5rem;
+  }
+
+  .sm\:-inset-3xl {
+    top: -3rem;
+    right: -3rem;
+    bottom: -3rem;
+    left: -3rem;
+  }
+
+  .sm\:-inset-4xl {
+    top: -4rem;
+    right: -4rem;
+    bottom: -4rem;
+    left: -4rem;
+  }
+
+  .sm\:-inset-5xl {
+    top: -8rem;
+    right: -8rem;
+    bottom: -8rem;
+    left: -8rem;
   }
 
   .sm\:inset-1\/2 {
@@ -26749,6 +31028,116 @@ video {
     left: 0.875rem;
   }
 
+  .sm\:inset-y-3xs {
+    top: .125rem;
+    bottom: .125rem;
+  }
+
+  .sm\:inset-x-3xs {
+    right: .125rem;
+    left: .125rem;
+  }
+
+  .sm\:inset-y-xxs {
+    top: .25rem;
+    bottom: .25rem;
+  }
+
+  .sm\:inset-x-xxs {
+    right: .25rem;
+    left: .25rem;
+  }
+
+  .sm\:inset-y-xs {
+    top: .5rem;
+    bottom: .5rem;
+  }
+
+  .sm\:inset-x-xs {
+    right: .5rem;
+    left: .5rem;
+  }
+
+  .sm\:inset-y-s {
+    top: .75rem;
+    bottom: .75rem;
+  }
+
+  .sm\:inset-x-s {
+    right: .75rem;
+    left: .75rem;
+  }
+
+  .sm\:inset-y-m {
+    top: 1rem;
+    bottom: 1rem;
+  }
+
+  .sm\:inset-x-m {
+    right: 1rem;
+    left: 1rem;
+  }
+
+  .sm\:inset-y-l {
+    top: 1.5rem;
+    bottom: 1.5rem;
+  }
+
+  .sm\:inset-x-l {
+    right: 1.5rem;
+    left: 1.5rem;
+  }
+
+  .sm\:inset-y-xl {
+    top: 2rem;
+    bottom: 2rem;
+  }
+
+  .sm\:inset-x-xl {
+    right: 2rem;
+    left: 2rem;
+  }
+
+  .sm\:inset-y-xxl {
+    top: 2.5rem;
+    bottom: 2.5rem;
+  }
+
+  .sm\:inset-x-xxl {
+    right: 2.5rem;
+    left: 2.5rem;
+  }
+
+  .sm\:inset-y-3xl {
+    top: 3rem;
+    bottom: 3rem;
+  }
+
+  .sm\:inset-x-3xl {
+    right: 3rem;
+    left: 3rem;
+  }
+
+  .sm\:inset-y-4xl {
+    top: 4rem;
+    bottom: 4rem;
+  }
+
+  .sm\:inset-x-4xl {
+    right: 4rem;
+    left: 4rem;
+  }
+
+  .sm\:inset-y-5xl {
+    top: 8rem;
+    bottom: 8rem;
+  }
+
+  .sm\:inset-x-5xl {
+    right: 8rem;
+    left: 8rem;
+  }
+
   .sm\:-inset-y-0 {
     top: 0px;
     bottom: 0px;
@@ -27097,6 +31486,116 @@ video {
   .sm\:-inset-x-3\.5 {
     right: -0.875rem;
     left: -0.875rem;
+  }
+
+  .sm\:-inset-y-3xs {
+    top: -0.125rem;
+    bottom: -0.125rem;
+  }
+
+  .sm\:-inset-x-3xs {
+    right: -0.125rem;
+    left: -0.125rem;
+  }
+
+  .sm\:-inset-y-xxs {
+    top: -0.25rem;
+    bottom: -0.25rem;
+  }
+
+  .sm\:-inset-x-xxs {
+    right: -0.25rem;
+    left: -0.25rem;
+  }
+
+  .sm\:-inset-y-xs {
+    top: -0.5rem;
+    bottom: -0.5rem;
+  }
+
+  .sm\:-inset-x-xs {
+    right: -0.5rem;
+    left: -0.5rem;
+  }
+
+  .sm\:-inset-y-s {
+    top: -0.75rem;
+    bottom: -0.75rem;
+  }
+
+  .sm\:-inset-x-s {
+    right: -0.75rem;
+    left: -0.75rem;
+  }
+
+  .sm\:-inset-y-m {
+    top: -1rem;
+    bottom: -1rem;
+  }
+
+  .sm\:-inset-x-m {
+    right: -1rem;
+    left: -1rem;
+  }
+
+  .sm\:-inset-y-l {
+    top: -1.5rem;
+    bottom: -1.5rem;
+  }
+
+  .sm\:-inset-x-l {
+    right: -1.5rem;
+    left: -1.5rem;
+  }
+
+  .sm\:-inset-y-xl {
+    top: -2rem;
+    bottom: -2rem;
+  }
+
+  .sm\:-inset-x-xl {
+    right: -2rem;
+    left: -2rem;
+  }
+
+  .sm\:-inset-y-xxl {
+    top: -2.5rem;
+    bottom: -2.5rem;
+  }
+
+  .sm\:-inset-x-xxl {
+    right: -2.5rem;
+    left: -2.5rem;
+  }
+
+  .sm\:-inset-y-3xl {
+    top: -3rem;
+    bottom: -3rem;
+  }
+
+  .sm\:-inset-x-3xl {
+    right: -3rem;
+    left: -3rem;
+  }
+
+  .sm\:-inset-y-4xl {
+    top: -4rem;
+    bottom: -4rem;
+  }
+
+  .sm\:-inset-x-4xl {
+    right: -4rem;
+    left: -4rem;
+  }
+
+  .sm\:-inset-y-5xl {
+    top: -8rem;
+    bottom: -8rem;
+  }
+
+  .sm\:-inset-x-5xl {
+    right: -8rem;
+    left: -8rem;
   }
 
   .sm\:inset-y-1\/2 {
@@ -27815,6 +32314,182 @@ video {
     left: 0.875rem;
   }
 
+  .sm\:top-3xs {
+    top: .125rem;
+  }
+
+  .sm\:right-3xs {
+    right: .125rem;
+  }
+
+  .sm\:bottom-3xs {
+    bottom: .125rem;
+  }
+
+  .sm\:left-3xs {
+    left: .125rem;
+  }
+
+  .sm\:top-xxs {
+    top: .25rem;
+  }
+
+  .sm\:right-xxs {
+    right: .25rem;
+  }
+
+  .sm\:bottom-xxs {
+    bottom: .25rem;
+  }
+
+  .sm\:left-xxs {
+    left: .25rem;
+  }
+
+  .sm\:top-xs {
+    top: .5rem;
+  }
+
+  .sm\:right-xs {
+    right: .5rem;
+  }
+
+  .sm\:bottom-xs {
+    bottom: .5rem;
+  }
+
+  .sm\:left-xs {
+    left: .5rem;
+  }
+
+  .sm\:top-s {
+    top: .75rem;
+  }
+
+  .sm\:right-s {
+    right: .75rem;
+  }
+
+  .sm\:bottom-s {
+    bottom: .75rem;
+  }
+
+  .sm\:left-s {
+    left: .75rem;
+  }
+
+  .sm\:top-m {
+    top: 1rem;
+  }
+
+  .sm\:right-m {
+    right: 1rem;
+  }
+
+  .sm\:bottom-m {
+    bottom: 1rem;
+  }
+
+  .sm\:left-m {
+    left: 1rem;
+  }
+
+  .sm\:top-l {
+    top: 1.5rem;
+  }
+
+  .sm\:right-l {
+    right: 1.5rem;
+  }
+
+  .sm\:bottom-l {
+    bottom: 1.5rem;
+  }
+
+  .sm\:left-l {
+    left: 1.5rem;
+  }
+
+  .sm\:top-xl {
+    top: 2rem;
+  }
+
+  .sm\:right-xl {
+    right: 2rem;
+  }
+
+  .sm\:bottom-xl {
+    bottom: 2rem;
+  }
+
+  .sm\:left-xl {
+    left: 2rem;
+  }
+
+  .sm\:top-xxl {
+    top: 2.5rem;
+  }
+
+  .sm\:right-xxl {
+    right: 2.5rem;
+  }
+
+  .sm\:bottom-xxl {
+    bottom: 2.5rem;
+  }
+
+  .sm\:left-xxl {
+    left: 2.5rem;
+  }
+
+  .sm\:top-3xl {
+    top: 3rem;
+  }
+
+  .sm\:right-3xl {
+    right: 3rem;
+  }
+
+  .sm\:bottom-3xl {
+    bottom: 3rem;
+  }
+
+  .sm\:left-3xl {
+    left: 3rem;
+  }
+
+  .sm\:top-4xl {
+    top: 4rem;
+  }
+
+  .sm\:right-4xl {
+    right: 4rem;
+  }
+
+  .sm\:bottom-4xl {
+    bottom: 4rem;
+  }
+
+  .sm\:left-4xl {
+    left: 4rem;
+  }
+
+  .sm\:top-5xl {
+    top: 8rem;
+  }
+
+  .sm\:right-5xl {
+    right: 8rem;
+  }
+
+  .sm\:bottom-5xl {
+    bottom: 8rem;
+  }
+
+  .sm\:left-5xl {
+    left: 8rem;
+  }
+
   .sm\:-top-0 {
     top: 0px;
   }
@@ -28373,6 +33048,182 @@ video {
 
   .sm\:-left-3\.5 {
     left: -0.875rem;
+  }
+
+  .sm\:-top-3xs {
+    top: -0.125rem;
+  }
+
+  .sm\:-right-3xs {
+    right: -0.125rem;
+  }
+
+  .sm\:-bottom-3xs {
+    bottom: -0.125rem;
+  }
+
+  .sm\:-left-3xs {
+    left: -0.125rem;
+  }
+
+  .sm\:-top-xxs {
+    top: -0.25rem;
+  }
+
+  .sm\:-right-xxs {
+    right: -0.25rem;
+  }
+
+  .sm\:-bottom-xxs {
+    bottom: -0.25rem;
+  }
+
+  .sm\:-left-xxs {
+    left: -0.25rem;
+  }
+
+  .sm\:-top-xs {
+    top: -0.5rem;
+  }
+
+  .sm\:-right-xs {
+    right: -0.5rem;
+  }
+
+  .sm\:-bottom-xs {
+    bottom: -0.5rem;
+  }
+
+  .sm\:-left-xs {
+    left: -0.5rem;
+  }
+
+  .sm\:-top-s {
+    top: -0.75rem;
+  }
+
+  .sm\:-right-s {
+    right: -0.75rem;
+  }
+
+  .sm\:-bottom-s {
+    bottom: -0.75rem;
+  }
+
+  .sm\:-left-s {
+    left: -0.75rem;
+  }
+
+  .sm\:-top-m {
+    top: -1rem;
+  }
+
+  .sm\:-right-m {
+    right: -1rem;
+  }
+
+  .sm\:-bottom-m {
+    bottom: -1rem;
+  }
+
+  .sm\:-left-m {
+    left: -1rem;
+  }
+
+  .sm\:-top-l {
+    top: -1.5rem;
+  }
+
+  .sm\:-right-l {
+    right: -1.5rem;
+  }
+
+  .sm\:-bottom-l {
+    bottom: -1.5rem;
+  }
+
+  .sm\:-left-l {
+    left: -1.5rem;
+  }
+
+  .sm\:-top-xl {
+    top: -2rem;
+  }
+
+  .sm\:-right-xl {
+    right: -2rem;
+  }
+
+  .sm\:-bottom-xl {
+    bottom: -2rem;
+  }
+
+  .sm\:-left-xl {
+    left: -2rem;
+  }
+
+  .sm\:-top-xxl {
+    top: -2.5rem;
+  }
+
+  .sm\:-right-xxl {
+    right: -2.5rem;
+  }
+
+  .sm\:-bottom-xxl {
+    bottom: -2.5rem;
+  }
+
+  .sm\:-left-xxl {
+    left: -2.5rem;
+  }
+
+  .sm\:-top-3xl {
+    top: -3rem;
+  }
+
+  .sm\:-right-3xl {
+    right: -3rem;
+  }
+
+  .sm\:-bottom-3xl {
+    bottom: -3rem;
+  }
+
+  .sm\:-left-3xl {
+    left: -3rem;
+  }
+
+  .sm\:-top-4xl {
+    top: -4rem;
+  }
+
+  .sm\:-right-4xl {
+    right: -4rem;
+  }
+
+  .sm\:-bottom-4xl {
+    bottom: -4rem;
+  }
+
+  .sm\:-left-4xl {
+    left: -4rem;
+  }
+
+  .sm\:-top-5xl {
+    top: -8rem;
+  }
+
+  .sm\:-right-5xl {
+    right: -8rem;
+  }
+
+  .sm\:-bottom-5xl {
+    bottom: -8rem;
+  }
+
+  .sm\:-left-5xl {
+    left: -8rem;
   }
 
   .sm\:top-1\/2 {
@@ -30248,6 +35099,50 @@ video {
     width: 0.875rem;
   }
 
+  .sm\:w-3xs {
+    width: .125rem;
+  }
+
+  .sm\:w-xxs {
+    width: .25rem;
+  }
+
+  .sm\:w-xs {
+    width: .5rem;
+  }
+
+  .sm\:w-s {
+    width: .75rem;
+  }
+
+  .sm\:w-m {
+    width: 1rem;
+  }
+
+  .sm\:w-l {
+    width: 1.5rem;
+  }
+
+  .sm\:w-xl {
+    width: 2rem;
+  }
+
+  .sm\:w-xxl {
+    width: 2.5rem;
+  }
+
+  .sm\:w-3xl {
+    width: 3rem;
+  }
+
+  .sm\:w-4xl {
+    width: 4rem;
+  }
+
+  .sm\:w-5xl {
+    width: 8rem;
+  }
+
   .sm\:w-1\/2 {
     width: 50%;
   }
@@ -30596,6 +35491,50 @@ video {
     gap: 0.875rem;
   }
 
+  .sm\:gap-3xs {
+    gap: .125rem;
+  }
+
+  .sm\:gap-xxs {
+    gap: .25rem;
+  }
+
+  .sm\:gap-xs {
+    gap: .5rem;
+  }
+
+  .sm\:gap-s {
+    gap: .75rem;
+  }
+
+  .sm\:gap-m {
+    gap: 1rem;
+  }
+
+  .sm\:gap-l {
+    gap: 1.5rem;
+  }
+
+  .sm\:gap-xl {
+    gap: 2rem;
+  }
+
+  .sm\:gap-xxl {
+    gap: 2.5rem;
+  }
+
+  .sm\:gap-3xl {
+    gap: 3rem;
+  }
+
+  .sm\:gap-4xl {
+    gap: 4rem;
+  }
+
+  .sm\:gap-5xl {
+    gap: 8rem;
+  }
+
   .sm\:gap-x-0 {
     -moz-column-gap: 0px;
          column-gap: 0px;
@@ -30771,6 +35710,61 @@ video {
          column-gap: 0.875rem;
   }
 
+  .sm\:gap-x-3xs {
+    -moz-column-gap: .125rem;
+         column-gap: .125rem;
+  }
+
+  .sm\:gap-x-xxs {
+    -moz-column-gap: .25rem;
+         column-gap: .25rem;
+  }
+
+  .sm\:gap-x-xs {
+    -moz-column-gap: .5rem;
+         column-gap: .5rem;
+  }
+
+  .sm\:gap-x-s {
+    -moz-column-gap: .75rem;
+         column-gap: .75rem;
+  }
+
+  .sm\:gap-x-m {
+    -moz-column-gap: 1rem;
+         column-gap: 1rem;
+  }
+
+  .sm\:gap-x-l {
+    -moz-column-gap: 1.5rem;
+         column-gap: 1.5rem;
+  }
+
+  .sm\:gap-x-xl {
+    -moz-column-gap: 2rem;
+         column-gap: 2rem;
+  }
+
+  .sm\:gap-x-xxl {
+    -moz-column-gap: 2.5rem;
+         column-gap: 2.5rem;
+  }
+
+  .sm\:gap-x-3xl {
+    -moz-column-gap: 3rem;
+         column-gap: 3rem;
+  }
+
+  .sm\:gap-x-4xl {
+    -moz-column-gap: 4rem;
+         column-gap: 4rem;
+  }
+
+  .sm\:gap-x-5xl {
+    -moz-column-gap: 8rem;
+         column-gap: 8rem;
+  }
+
   .sm\:gap-y-0 {
     row-gap: 0px;
   }
@@ -30909,6 +35903,50 @@ video {
 
   .sm\:gap-y-3\.5 {
     row-gap: 0.875rem;
+  }
+
+  .sm\:gap-y-3xs {
+    row-gap: .125rem;
+  }
+
+  .sm\:gap-y-xxs {
+    row-gap: .25rem;
+  }
+
+  .sm\:gap-y-xs {
+    row-gap: .5rem;
+  }
+
+  .sm\:gap-y-s {
+    row-gap: .75rem;
+  }
+
+  .sm\:gap-y-m {
+    row-gap: 1rem;
+  }
+
+  .sm\:gap-y-l {
+    row-gap: 1.5rem;
+  }
+
+  .sm\:gap-y-xl {
+    row-gap: 2rem;
+  }
+
+  .sm\:gap-y-xxl {
+    row-gap: 2.5rem;
+  }
+
+  .sm\:gap-y-3xl {
+    row-gap: 3rem;
+  }
+
+  .sm\:gap-y-4xl {
+    row-gap: 4rem;
+  }
+
+  .sm\:gap-y-5xl {
+    row-gap: 8rem;
   }
 
   .sm\:grid-flow-row {
@@ -32103,6 +37141,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .sm\:translate-x-3xs {
+    --tw-translate-x: .125rem;
+  }
+
+  .sm\:translate-x-xxs {
+    --tw-translate-x: .25rem;
+  }
+
+  .sm\:translate-x-xs {
+    --tw-translate-x: .5rem;
+  }
+
+  .sm\:translate-x-s {
+    --tw-translate-x: .75rem;
+  }
+
+  .sm\:translate-x-m {
+    --tw-translate-x: 1rem;
+  }
+
+  .sm\:translate-x-l {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .sm\:translate-x-xl {
+    --tw-translate-x: 2rem;
+  }
+
+  .sm\:translate-x-xxl {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .sm\:translate-x-3xl {
+    --tw-translate-x: 3rem;
+  }
+
+  .sm\:translate-x-4xl {
+    --tw-translate-x: 4rem;
+  }
+
+  .sm\:translate-x-5xl {
+    --tw-translate-x: 8rem;
+  }
+
   .sm\:-translate-x-0 {
     --tw-translate-x: 0px;
   }
@@ -32241,6 +37323,50 @@ video {
 
   .sm\:-translate-x-3\.5 {
     --tw-translate-x: -0.875rem;
+  }
+
+  .sm\:-translate-x-3xs {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .sm\:-translate-x-xxs {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .sm\:-translate-x-xs {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .sm\:-translate-x-s {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .sm\:-translate-x-m {
+    --tw-translate-x: -1rem;
+  }
+
+  .sm\:-translate-x-l {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .sm\:-translate-x-xl {
+    --tw-translate-x: -2rem;
+  }
+
+  .sm\:-translate-x-xxl {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .sm\:-translate-x-3xl {
+    --tw-translate-x: -3rem;
+  }
+
+  .sm\:-translate-x-4xl {
+    --tw-translate-x: -4rem;
+  }
+
+  .sm\:-translate-x-5xl {
+    --tw-translate-x: -8rem;
   }
 
   .sm\:translate-x-1\/2 {
@@ -32439,6 +37565,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .sm\:translate-y-3xs {
+    --tw-translate-y: .125rem;
+  }
+
+  .sm\:translate-y-xxs {
+    --tw-translate-y: .25rem;
+  }
+
+  .sm\:translate-y-xs {
+    --tw-translate-y: .5rem;
+  }
+
+  .sm\:translate-y-s {
+    --tw-translate-y: .75rem;
+  }
+
+  .sm\:translate-y-m {
+    --tw-translate-y: 1rem;
+  }
+
+  .sm\:translate-y-l {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .sm\:translate-y-xl {
+    --tw-translate-y: 2rem;
+  }
+
+  .sm\:translate-y-xxl {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .sm\:translate-y-3xl {
+    --tw-translate-y: 3rem;
+  }
+
+  .sm\:translate-y-4xl {
+    --tw-translate-y: 4rem;
+  }
+
+  .sm\:translate-y-5xl {
+    --tw-translate-y: 8rem;
+  }
+
   .sm\:-translate-y-0 {
     --tw-translate-y: 0px;
   }
@@ -32577,6 +37747,50 @@ video {
 
   .sm\:-translate-y-3\.5 {
     --tw-translate-y: -0.875rem;
+  }
+
+  .sm\:-translate-y-3xs {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .sm\:-translate-y-xxs {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .sm\:-translate-y-xs {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .sm\:-translate-y-s {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .sm\:-translate-y-m {
+    --tw-translate-y: -1rem;
+  }
+
+  .sm\:-translate-y-l {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .sm\:-translate-y-xl {
+    --tw-translate-y: -2rem;
+  }
+
+  .sm\:-translate-y-xxl {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .sm\:-translate-y-3xl {
+    --tw-translate-y: -3rem;
+  }
+
+  .sm\:-translate-y-4xl {
+    --tw-translate-y: -4rem;
+  }
+
+  .sm\:-translate-y-5xl {
+    --tw-translate-y: -8rem;
   }
 
   .sm\:translate-y-1\/2 {
@@ -32775,6 +37989,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .sm\:hover\:translate-x-3xs:hover {
+    --tw-translate-x: .125rem;
+  }
+
+  .sm\:hover\:translate-x-xxs:hover {
+    --tw-translate-x: .25rem;
+  }
+
+  .sm\:hover\:translate-x-xs:hover {
+    --tw-translate-x: .5rem;
+  }
+
+  .sm\:hover\:translate-x-s:hover {
+    --tw-translate-x: .75rem;
+  }
+
+  .sm\:hover\:translate-x-m:hover {
+    --tw-translate-x: 1rem;
+  }
+
+  .sm\:hover\:translate-x-l:hover {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .sm\:hover\:translate-x-xl:hover {
+    --tw-translate-x: 2rem;
+  }
+
+  .sm\:hover\:translate-x-xxl:hover {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .sm\:hover\:translate-x-3xl:hover {
+    --tw-translate-x: 3rem;
+  }
+
+  .sm\:hover\:translate-x-4xl:hover {
+    --tw-translate-x: 4rem;
+  }
+
+  .sm\:hover\:translate-x-5xl:hover {
+    --tw-translate-x: 8rem;
+  }
+
   .sm\:hover\:-translate-x-0:hover {
     --tw-translate-x: 0px;
   }
@@ -32913,6 +38171,50 @@ video {
 
   .sm\:hover\:-translate-x-3\.5:hover {
     --tw-translate-x: -0.875rem;
+  }
+
+  .sm\:hover\:-translate-x-3xs:hover {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .sm\:hover\:-translate-x-xxs:hover {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .sm\:hover\:-translate-x-xs:hover {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .sm\:hover\:-translate-x-s:hover {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .sm\:hover\:-translate-x-m:hover {
+    --tw-translate-x: -1rem;
+  }
+
+  .sm\:hover\:-translate-x-l:hover {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .sm\:hover\:-translate-x-xl:hover {
+    --tw-translate-x: -2rem;
+  }
+
+  .sm\:hover\:-translate-x-xxl:hover {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .sm\:hover\:-translate-x-3xl:hover {
+    --tw-translate-x: -3rem;
+  }
+
+  .sm\:hover\:-translate-x-4xl:hover {
+    --tw-translate-x: -4rem;
+  }
+
+  .sm\:hover\:-translate-x-5xl:hover {
+    --tw-translate-x: -8rem;
   }
 
   .sm\:hover\:translate-x-1\/2:hover {
@@ -33111,6 +38413,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .sm\:hover\:translate-y-3xs:hover {
+    --tw-translate-y: .125rem;
+  }
+
+  .sm\:hover\:translate-y-xxs:hover {
+    --tw-translate-y: .25rem;
+  }
+
+  .sm\:hover\:translate-y-xs:hover {
+    --tw-translate-y: .5rem;
+  }
+
+  .sm\:hover\:translate-y-s:hover {
+    --tw-translate-y: .75rem;
+  }
+
+  .sm\:hover\:translate-y-m:hover {
+    --tw-translate-y: 1rem;
+  }
+
+  .sm\:hover\:translate-y-l:hover {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .sm\:hover\:translate-y-xl:hover {
+    --tw-translate-y: 2rem;
+  }
+
+  .sm\:hover\:translate-y-xxl:hover {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .sm\:hover\:translate-y-3xl:hover {
+    --tw-translate-y: 3rem;
+  }
+
+  .sm\:hover\:translate-y-4xl:hover {
+    --tw-translate-y: 4rem;
+  }
+
+  .sm\:hover\:translate-y-5xl:hover {
+    --tw-translate-y: 8rem;
+  }
+
   .sm\:hover\:-translate-y-0:hover {
     --tw-translate-y: 0px;
   }
@@ -33249,6 +38595,50 @@ video {
 
   .sm\:hover\:-translate-y-3\.5:hover {
     --tw-translate-y: -0.875rem;
+  }
+
+  .sm\:hover\:-translate-y-3xs:hover {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .sm\:hover\:-translate-y-xxs:hover {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .sm\:hover\:-translate-y-xs:hover {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .sm\:hover\:-translate-y-s:hover {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .sm\:hover\:-translate-y-m:hover {
+    --tw-translate-y: -1rem;
+  }
+
+  .sm\:hover\:-translate-y-l:hover {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .sm\:hover\:-translate-y-xl:hover {
+    --tw-translate-y: -2rem;
+  }
+
+  .sm\:hover\:-translate-y-xxl:hover {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .sm\:hover\:-translate-y-3xl:hover {
+    --tw-translate-y: -3rem;
+  }
+
+  .sm\:hover\:-translate-y-4xl:hover {
+    --tw-translate-y: -4rem;
+  }
+
+  .sm\:hover\:-translate-y-5xl:hover {
+    --tw-translate-y: -8rem;
   }
 
   .sm\:hover\:translate-y-1\/2:hover {
@@ -33447,6 +38837,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .sm\:focus\:translate-x-3xs:focus {
+    --tw-translate-x: .125rem;
+  }
+
+  .sm\:focus\:translate-x-xxs:focus {
+    --tw-translate-x: .25rem;
+  }
+
+  .sm\:focus\:translate-x-xs:focus {
+    --tw-translate-x: .5rem;
+  }
+
+  .sm\:focus\:translate-x-s:focus {
+    --tw-translate-x: .75rem;
+  }
+
+  .sm\:focus\:translate-x-m:focus {
+    --tw-translate-x: 1rem;
+  }
+
+  .sm\:focus\:translate-x-l:focus {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .sm\:focus\:translate-x-xl:focus {
+    --tw-translate-x: 2rem;
+  }
+
+  .sm\:focus\:translate-x-xxl:focus {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .sm\:focus\:translate-x-3xl:focus {
+    --tw-translate-x: 3rem;
+  }
+
+  .sm\:focus\:translate-x-4xl:focus {
+    --tw-translate-x: 4rem;
+  }
+
+  .sm\:focus\:translate-x-5xl:focus {
+    --tw-translate-x: 8rem;
+  }
+
   .sm\:focus\:-translate-x-0:focus {
     --tw-translate-x: 0px;
   }
@@ -33585,6 +39019,50 @@ video {
 
   .sm\:focus\:-translate-x-3\.5:focus {
     --tw-translate-x: -0.875rem;
+  }
+
+  .sm\:focus\:-translate-x-3xs:focus {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .sm\:focus\:-translate-x-xxs:focus {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .sm\:focus\:-translate-x-xs:focus {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .sm\:focus\:-translate-x-s:focus {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .sm\:focus\:-translate-x-m:focus {
+    --tw-translate-x: -1rem;
+  }
+
+  .sm\:focus\:-translate-x-l:focus {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .sm\:focus\:-translate-x-xl:focus {
+    --tw-translate-x: -2rem;
+  }
+
+  .sm\:focus\:-translate-x-xxl:focus {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .sm\:focus\:-translate-x-3xl:focus {
+    --tw-translate-x: -3rem;
+  }
+
+  .sm\:focus\:-translate-x-4xl:focus {
+    --tw-translate-x: -4rem;
+  }
+
+  .sm\:focus\:-translate-x-5xl:focus {
+    --tw-translate-x: -8rem;
   }
 
   .sm\:focus\:translate-x-1\/2:focus {
@@ -33783,6 +39261,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .sm\:focus\:translate-y-3xs:focus {
+    --tw-translate-y: .125rem;
+  }
+
+  .sm\:focus\:translate-y-xxs:focus {
+    --tw-translate-y: .25rem;
+  }
+
+  .sm\:focus\:translate-y-xs:focus {
+    --tw-translate-y: .5rem;
+  }
+
+  .sm\:focus\:translate-y-s:focus {
+    --tw-translate-y: .75rem;
+  }
+
+  .sm\:focus\:translate-y-m:focus {
+    --tw-translate-y: 1rem;
+  }
+
+  .sm\:focus\:translate-y-l:focus {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .sm\:focus\:translate-y-xl:focus {
+    --tw-translate-y: 2rem;
+  }
+
+  .sm\:focus\:translate-y-xxl:focus {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .sm\:focus\:translate-y-3xl:focus {
+    --tw-translate-y: 3rem;
+  }
+
+  .sm\:focus\:translate-y-4xl:focus {
+    --tw-translate-y: 4rem;
+  }
+
+  .sm\:focus\:translate-y-5xl:focus {
+    --tw-translate-y: 8rem;
+  }
+
   .sm\:focus\:-translate-y-0:focus {
     --tw-translate-y: 0px;
   }
@@ -33921,6 +39443,50 @@ video {
 
   .sm\:focus\:-translate-y-3\.5:focus {
     --tw-translate-y: -0.875rem;
+  }
+
+  .sm\:focus\:-translate-y-3xs:focus {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .sm\:focus\:-translate-y-xxs:focus {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .sm\:focus\:-translate-y-xs:focus {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .sm\:focus\:-translate-y-s:focus {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .sm\:focus\:-translate-y-m:focus {
+    --tw-translate-y: -1rem;
+  }
+
+  .sm\:focus\:-translate-y-l:focus {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .sm\:focus\:-translate-y-xl:focus {
+    --tw-translate-y: -2rem;
+  }
+
+  .sm\:focus\:-translate-y-xxl:focus {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .sm\:focus\:-translate-y-3xl:focus {
+    --tw-translate-y: -3rem;
+  }
+
+  .sm\:focus\:-translate-y-4xl:focus {
+    --tw-translate-y: -4rem;
+  }
+
+  .sm\:focus\:-translate-y-5xl:focus {
+    --tw-translate-y: -8rem;
   }
 
   .sm\:focus\:translate-y-1\/2:focus {
@@ -34844,6 +40410,138 @@ video {
     margin-left: calc(0.875rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
+  .md\:space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.125rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.125rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.125rem * var(--tw-space-x-reverse));
+    margin-left: calc(.125rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.25rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.25rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-y-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.5rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-y-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.75rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.75rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-y-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1rem * var(--tw-space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-y-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-y-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2rem * var(--tw-space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(2.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(2.5rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(3rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(3rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(3rem * var(--tw-space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(4rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(4rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(4rem * var(--tw-space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(8rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(8rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(8rem * var(--tw-space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
   .md\:-space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
@@ -35262,6 +40960,138 @@ video {
     --tw-space-x-reverse: 0;
     margin-right: calc(-0.875rem * var(--tw-space-x-reverse));
     margin-left: calc(-0.875rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.125rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.125rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.125rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.25rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.25rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.5rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.75rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.75rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-1rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-1rem * var(--tw-space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-1.5rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-2rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-2rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-2rem * var(--tw-space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-2.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-2.5rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-3rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-3rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-3rem * var(--tw-space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-4rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-4rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-4rem * var(--tw-space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:-space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-8rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-8rem * var(--tw-space-y-reverse));
+  }
+
+  .md\:-space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-8rem * var(--tw-space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .md\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -37920,6 +43750,50 @@ video {
     height: 0.875rem;
   }
 
+  .md\:h-3xs {
+    height: .125rem;
+  }
+
+  .md\:h-xxs {
+    height: .25rem;
+  }
+
+  .md\:h-xs {
+    height: .5rem;
+  }
+
+  .md\:h-s {
+    height: .75rem;
+  }
+
+  .md\:h-m {
+    height: 1rem;
+  }
+
+  .md\:h-l {
+    height: 1.5rem;
+  }
+
+  .md\:h-xl {
+    height: 2rem;
+  }
+
+  .md\:h-xxl {
+    height: 2.5rem;
+  }
+
+  .md\:h-3xl {
+    height: 3rem;
+  }
+
+  .md\:h-4xl {
+    height: 4rem;
+  }
+
+  .md\:h-5xl {
+    height: 8rem;
+  }
+
   .md\:h-1\/2 {
     height: 50%;
   }
@@ -38236,6 +44110,50 @@ video {
     margin: 0.875rem;
   }
 
+  .md\:m-3xs {
+    margin: .125rem;
+  }
+
+  .md\:m-xxs {
+    margin: .25rem;
+  }
+
+  .md\:m-xs {
+    margin: .5rem;
+  }
+
+  .md\:m-s {
+    margin: .75rem;
+  }
+
+  .md\:m-m {
+    margin: 1rem;
+  }
+
+  .md\:m-l {
+    margin: 1.5rem;
+  }
+
+  .md\:m-xl {
+    margin: 2rem;
+  }
+
+  .md\:m-xxl {
+    margin: 2.5rem;
+  }
+
+  .md\:m-3xl {
+    margin: 3rem;
+  }
+
+  .md\:m-4xl {
+    margin: 4rem;
+  }
+
+  .md\:m-5xl {
+    margin: 8rem;
+  }
+
   .md\:-m-0 {
     margin: 0px;
   }
@@ -38374,6 +44292,50 @@ video {
 
   .md\:-m-3\.5 {
     margin: -0.875rem;
+  }
+
+  .md\:-m-3xs {
+    margin: -0.125rem;
+  }
+
+  .md\:-m-xxs {
+    margin: -0.25rem;
+  }
+
+  .md\:-m-xs {
+    margin: -0.5rem;
+  }
+
+  .md\:-m-s {
+    margin: -0.75rem;
+  }
+
+  .md\:-m-m {
+    margin: -1rem;
+  }
+
+  .md\:-m-l {
+    margin: -1.5rem;
+  }
+
+  .md\:-m-xl {
+    margin: -2rem;
+  }
+
+  .md\:-m-xxl {
+    margin: -2.5rem;
+  }
+
+  .md\:-m-3xl {
+    margin: -3rem;
+  }
+
+  .md\:-m-4xl {
+    margin: -4rem;
+  }
+
+  .md\:-m-5xl {
+    margin: -8rem;
   }
 
   .md\:my-0 {
@@ -38736,6 +44698,116 @@ video {
     margin-right: 0.875rem;
   }
 
+  .md\:my-3xs {
+    margin-top: .125rem;
+    margin-bottom: .125rem;
+  }
+
+  .md\:mx-3xs {
+    margin-left: .125rem;
+    margin-right: .125rem;
+  }
+
+  .md\:my-xxs {
+    margin-top: .25rem;
+    margin-bottom: .25rem;
+  }
+
+  .md\:mx-xxs {
+    margin-left: .25rem;
+    margin-right: .25rem;
+  }
+
+  .md\:my-xs {
+    margin-top: .5rem;
+    margin-bottom: .5rem;
+  }
+
+  .md\:mx-xs {
+    margin-left: .5rem;
+    margin-right: .5rem;
+  }
+
+  .md\:my-s {
+    margin-top: .75rem;
+    margin-bottom: .75rem;
+  }
+
+  .md\:mx-s {
+    margin-left: .75rem;
+    margin-right: .75rem;
+  }
+
+  .md\:my-m {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .md\:mx-m {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+
+  .md\:my-l {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .md\:mx-l {
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+
+  .md\:my-xl {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .md\:mx-xl {
+    margin-left: 2rem;
+    margin-right: 2rem;
+  }
+
+  .md\:my-xxl {
+    margin-top: 2.5rem;
+    margin-bottom: 2.5rem;
+  }
+
+  .md\:mx-xxl {
+    margin-left: 2.5rem;
+    margin-right: 2.5rem;
+  }
+
+  .md\:my-3xl {
+    margin-top: 3rem;
+    margin-bottom: 3rem;
+  }
+
+  .md\:mx-3xl {
+    margin-left: 3rem;
+    margin-right: 3rem;
+  }
+
+  .md\:my-4xl {
+    margin-top: 4rem;
+    margin-bottom: 4rem;
+  }
+
+  .md\:mx-4xl {
+    margin-left: 4rem;
+    margin-right: 4rem;
+  }
+
+  .md\:my-5xl {
+    margin-top: 8rem;
+    margin-bottom: 8rem;
+  }
+
+  .md\:mx-5xl {
+    margin-left: 8rem;
+    margin-right: 8rem;
+  }
+
   .md\:-my-0 {
     margin-top: 0px;
     margin-bottom: 0px;
@@ -39084,6 +45156,116 @@ video {
   .md\:-mx-3\.5 {
     margin-left: -0.875rem;
     margin-right: -0.875rem;
+  }
+
+  .md\:-my-3xs {
+    margin-top: -0.125rem;
+    margin-bottom: -0.125rem;
+  }
+
+  .md\:-mx-3xs {
+    margin-left: -0.125rem;
+    margin-right: -0.125rem;
+  }
+
+  .md\:-my-xxs {
+    margin-top: -0.25rem;
+    margin-bottom: -0.25rem;
+  }
+
+  .md\:-mx-xxs {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+  }
+
+  .md\:-my-xs {
+    margin-top: -0.5rem;
+    margin-bottom: -0.5rem;
+  }
+
+  .md\:-mx-xs {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+  }
+
+  .md\:-my-s {
+    margin-top: -0.75rem;
+    margin-bottom: -0.75rem;
+  }
+
+  .md\:-mx-s {
+    margin-left: -0.75rem;
+    margin-right: -0.75rem;
+  }
+
+  .md\:-my-m {
+    margin-top: -1rem;
+    margin-bottom: -1rem;
+  }
+
+  .md\:-mx-m {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+
+  .md\:-my-l {
+    margin-top: -1.5rem;
+    margin-bottom: -1.5rem;
+  }
+
+  .md\:-mx-l {
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+  }
+
+  .md\:-my-xl {
+    margin-top: -2rem;
+    margin-bottom: -2rem;
+  }
+
+  .md\:-mx-xl {
+    margin-left: -2rem;
+    margin-right: -2rem;
+  }
+
+  .md\:-my-xxl {
+    margin-top: -2.5rem;
+    margin-bottom: -2.5rem;
+  }
+
+  .md\:-mx-xxl {
+    margin-left: -2.5rem;
+    margin-right: -2.5rem;
+  }
+
+  .md\:-my-3xl {
+    margin-top: -3rem;
+    margin-bottom: -3rem;
+  }
+
+  .md\:-mx-3xl {
+    margin-left: -3rem;
+    margin-right: -3rem;
+  }
+
+  .md\:-my-4xl {
+    margin-top: -4rem;
+    margin-bottom: -4rem;
+  }
+
+  .md\:-mx-4xl {
+    margin-left: -4rem;
+    margin-right: -4rem;
+  }
+
+  .md\:-my-5xl {
+    margin-top: -8rem;
+    margin-bottom: -8rem;
+  }
+
+  .md\:-mx-5xl {
+    margin-left: -8rem;
+    margin-right: -8rem;
   }
 
   .md\:mt-0 {
@@ -39662,6 +45844,182 @@ video {
     margin-left: 0.875rem;
   }
 
+  .md\:mt-3xs {
+    margin-top: .125rem;
+  }
+
+  .md\:mr-3xs {
+    margin-right: .125rem;
+  }
+
+  .md\:mb-3xs {
+    margin-bottom: .125rem;
+  }
+
+  .md\:ml-3xs {
+    margin-left: .125rem;
+  }
+
+  .md\:mt-xxs {
+    margin-top: .25rem;
+  }
+
+  .md\:mr-xxs {
+    margin-right: .25rem;
+  }
+
+  .md\:mb-xxs {
+    margin-bottom: .25rem;
+  }
+
+  .md\:ml-xxs {
+    margin-left: .25rem;
+  }
+
+  .md\:mt-xs {
+    margin-top: .5rem;
+  }
+
+  .md\:mr-xs {
+    margin-right: .5rem;
+  }
+
+  .md\:mb-xs {
+    margin-bottom: .5rem;
+  }
+
+  .md\:ml-xs {
+    margin-left: .5rem;
+  }
+
+  .md\:mt-s {
+    margin-top: .75rem;
+  }
+
+  .md\:mr-s {
+    margin-right: .75rem;
+  }
+
+  .md\:mb-s {
+    margin-bottom: .75rem;
+  }
+
+  .md\:ml-s {
+    margin-left: .75rem;
+  }
+
+  .md\:mt-m {
+    margin-top: 1rem;
+  }
+
+  .md\:mr-m {
+    margin-right: 1rem;
+  }
+
+  .md\:mb-m {
+    margin-bottom: 1rem;
+  }
+
+  .md\:ml-m {
+    margin-left: 1rem;
+  }
+
+  .md\:mt-l {
+    margin-top: 1.5rem;
+  }
+
+  .md\:mr-l {
+    margin-right: 1.5rem;
+  }
+
+  .md\:mb-l {
+    margin-bottom: 1.5rem;
+  }
+
+  .md\:ml-l {
+    margin-left: 1.5rem;
+  }
+
+  .md\:mt-xl {
+    margin-top: 2rem;
+  }
+
+  .md\:mr-xl {
+    margin-right: 2rem;
+  }
+
+  .md\:mb-xl {
+    margin-bottom: 2rem;
+  }
+
+  .md\:ml-xl {
+    margin-left: 2rem;
+  }
+
+  .md\:mt-xxl {
+    margin-top: 2.5rem;
+  }
+
+  .md\:mr-xxl {
+    margin-right: 2.5rem;
+  }
+
+  .md\:mb-xxl {
+    margin-bottom: 2.5rem;
+  }
+
+  .md\:ml-xxl {
+    margin-left: 2.5rem;
+  }
+
+  .md\:mt-3xl {
+    margin-top: 3rem;
+  }
+
+  .md\:mr-3xl {
+    margin-right: 3rem;
+  }
+
+  .md\:mb-3xl {
+    margin-bottom: 3rem;
+  }
+
+  .md\:ml-3xl {
+    margin-left: 3rem;
+  }
+
+  .md\:mt-4xl {
+    margin-top: 4rem;
+  }
+
+  .md\:mr-4xl {
+    margin-right: 4rem;
+  }
+
+  .md\:mb-4xl {
+    margin-bottom: 4rem;
+  }
+
+  .md\:ml-4xl {
+    margin-left: 4rem;
+  }
+
+  .md\:mt-5xl {
+    margin-top: 8rem;
+  }
+
+  .md\:mr-5xl {
+    margin-right: 8rem;
+  }
+
+  .md\:mb-5xl {
+    margin-bottom: 8rem;
+  }
+
+  .md\:ml-5xl {
+    margin-left: 8rem;
+  }
+
   .md\:-mt-0 {
     margin-top: 0px;
   }
@@ -40222,6 +46580,182 @@ video {
     margin-left: -0.875rem;
   }
 
+  .md\:-mt-3xs {
+    margin-top: -0.125rem;
+  }
+
+  .md\:-mr-3xs {
+    margin-right: -0.125rem;
+  }
+
+  .md\:-mb-3xs {
+    margin-bottom: -0.125rem;
+  }
+
+  .md\:-ml-3xs {
+    margin-left: -0.125rem;
+  }
+
+  .md\:-mt-xxs {
+    margin-top: -0.25rem;
+  }
+
+  .md\:-mr-xxs {
+    margin-right: -0.25rem;
+  }
+
+  .md\:-mb-xxs {
+    margin-bottom: -0.25rem;
+  }
+
+  .md\:-ml-xxs {
+    margin-left: -0.25rem;
+  }
+
+  .md\:-mt-xs {
+    margin-top: -0.5rem;
+  }
+
+  .md\:-mr-xs {
+    margin-right: -0.5rem;
+  }
+
+  .md\:-mb-xs {
+    margin-bottom: -0.5rem;
+  }
+
+  .md\:-ml-xs {
+    margin-left: -0.5rem;
+  }
+
+  .md\:-mt-s {
+    margin-top: -0.75rem;
+  }
+
+  .md\:-mr-s {
+    margin-right: -0.75rem;
+  }
+
+  .md\:-mb-s {
+    margin-bottom: -0.75rem;
+  }
+
+  .md\:-ml-s {
+    margin-left: -0.75rem;
+  }
+
+  .md\:-mt-m {
+    margin-top: -1rem;
+  }
+
+  .md\:-mr-m {
+    margin-right: -1rem;
+  }
+
+  .md\:-mb-m {
+    margin-bottom: -1rem;
+  }
+
+  .md\:-ml-m {
+    margin-left: -1rem;
+  }
+
+  .md\:-mt-l {
+    margin-top: -1.5rem;
+  }
+
+  .md\:-mr-l {
+    margin-right: -1.5rem;
+  }
+
+  .md\:-mb-l {
+    margin-bottom: -1.5rem;
+  }
+
+  .md\:-ml-l {
+    margin-left: -1.5rem;
+  }
+
+  .md\:-mt-xl {
+    margin-top: -2rem;
+  }
+
+  .md\:-mr-xl {
+    margin-right: -2rem;
+  }
+
+  .md\:-mb-xl {
+    margin-bottom: -2rem;
+  }
+
+  .md\:-ml-xl {
+    margin-left: -2rem;
+  }
+
+  .md\:-mt-xxl {
+    margin-top: -2.5rem;
+  }
+
+  .md\:-mr-xxl {
+    margin-right: -2.5rem;
+  }
+
+  .md\:-mb-xxl {
+    margin-bottom: -2.5rem;
+  }
+
+  .md\:-ml-xxl {
+    margin-left: -2.5rem;
+  }
+
+  .md\:-mt-3xl {
+    margin-top: -3rem;
+  }
+
+  .md\:-mr-3xl {
+    margin-right: -3rem;
+  }
+
+  .md\:-mb-3xl {
+    margin-bottom: -3rem;
+  }
+
+  .md\:-ml-3xl {
+    margin-left: -3rem;
+  }
+
+  .md\:-mt-4xl {
+    margin-top: -4rem;
+  }
+
+  .md\:-mr-4xl {
+    margin-right: -4rem;
+  }
+
+  .md\:-mb-4xl {
+    margin-bottom: -4rem;
+  }
+
+  .md\:-ml-4xl {
+    margin-left: -4rem;
+  }
+
+  .md\:-mt-5xl {
+    margin-top: -8rem;
+  }
+
+  .md\:-mr-5xl {
+    margin-right: -8rem;
+  }
+
+  .md\:-mb-5xl {
+    margin-bottom: -8rem;
+  }
+
+  .md\:-ml-5xl {
+    margin-left: -8rem;
+  }
+
   .md\:max-h-0 {
     max-height: 0px;
   }
@@ -40360,6 +46894,50 @@ video {
 
   .md\:max-h-3\.5 {
     max-height: 0.875rem;
+  }
+
+  .md\:max-h-3xs {
+    max-height: .125rem;
+  }
+
+  .md\:max-h-xxs {
+    max-height: .25rem;
+  }
+
+  .md\:max-h-xs {
+    max-height: .5rem;
+  }
+
+  .md\:max-h-s {
+    max-height: .75rem;
+  }
+
+  .md\:max-h-m {
+    max-height: 1rem;
+  }
+
+  .md\:max-h-l {
+    max-height: 1.5rem;
+  }
+
+  .md\:max-h-xl {
+    max-height: 2rem;
+  }
+
+  .md\:max-h-xxl {
+    max-height: 2.5rem;
+  }
+
+  .md\:max-h-3xl {
+    max-height: 3rem;
+  }
+
+  .md\:max-h-4xl {
+    max-height: 4rem;
+  }
+
+  .md\:max-h-5xl {
+    max-height: 8rem;
   }
 
   .md\:max-h-full {
@@ -41136,6 +47714,50 @@ video {
     padding: 0.875rem;
   }
 
+  .md\:p-3xs {
+    padding: .125rem;
+  }
+
+  .md\:p-xxs {
+    padding: .25rem;
+  }
+
+  .md\:p-xs {
+    padding: .5rem;
+  }
+
+  .md\:p-s {
+    padding: .75rem;
+  }
+
+  .md\:p-m {
+    padding: 1rem;
+  }
+
+  .md\:p-l {
+    padding: 1.5rem;
+  }
+
+  .md\:p-xl {
+    padding: 2rem;
+  }
+
+  .md\:p-xxl {
+    padding: 2.5rem;
+  }
+
+  .md\:p-3xl {
+    padding: 3rem;
+  }
+
+  .md\:p-4xl {
+    padding: 4rem;
+  }
+
+  .md\:p-5xl {
+    padding: 8rem;
+  }
+
   .md\:py-0 {
     padding-top: 0px;
     padding-bottom: 0px;
@@ -41484,6 +48106,116 @@ video {
   .md\:px-3\.5 {
     padding-left: 0.875rem;
     padding-right: 0.875rem;
+  }
+
+  .md\:py-3xs {
+    padding-top: .125rem;
+    padding-bottom: .125rem;
+  }
+
+  .md\:px-3xs {
+    padding-left: .125rem;
+    padding-right: .125rem;
+  }
+
+  .md\:py-xxs {
+    padding-top: .25rem;
+    padding-bottom: .25rem;
+  }
+
+  .md\:px-xxs {
+    padding-left: .25rem;
+    padding-right: .25rem;
+  }
+
+  .md\:py-xs {
+    padding-top: .5rem;
+    padding-bottom: .5rem;
+  }
+
+  .md\:px-xs {
+    padding-left: .5rem;
+    padding-right: .5rem;
+  }
+
+  .md\:py-s {
+    padding-top: .75rem;
+    padding-bottom: .75rem;
+  }
+
+  .md\:px-s {
+    padding-left: .75rem;
+    padding-right: .75rem;
+  }
+
+  .md\:py-m {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .md\:px-m {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .md\:py-l {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .md\:px-l {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .md\:py-xl {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+
+  .md\:px-xl {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
+  .md\:py-xxl {
+    padding-top: 2.5rem;
+    padding-bottom: 2.5rem;
+  }
+
+  .md\:px-xxl {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+  }
+
+  .md\:py-3xl {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+
+  .md\:px-3xl {
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
+
+  .md\:py-4xl {
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+  }
+
+  .md\:px-4xl {
+    padding-left: 4rem;
+    padding-right: 4rem;
+  }
+
+  .md\:py-5xl {
+    padding-top: 8rem;
+    padding-bottom: 8rem;
+  }
+
+  .md\:px-5xl {
+    padding-left: 8rem;
+    padding-right: 8rem;
   }
 
   .md\:pt-0 {
@@ -42044,6 +48776,182 @@ video {
 
   .md\:pl-3\.5 {
     padding-left: 0.875rem;
+  }
+
+  .md\:pt-3xs {
+    padding-top: .125rem;
+  }
+
+  .md\:pr-3xs {
+    padding-right: .125rem;
+  }
+
+  .md\:pb-3xs {
+    padding-bottom: .125rem;
+  }
+
+  .md\:pl-3xs {
+    padding-left: .125rem;
+  }
+
+  .md\:pt-xxs {
+    padding-top: .25rem;
+  }
+
+  .md\:pr-xxs {
+    padding-right: .25rem;
+  }
+
+  .md\:pb-xxs {
+    padding-bottom: .25rem;
+  }
+
+  .md\:pl-xxs {
+    padding-left: .25rem;
+  }
+
+  .md\:pt-xs {
+    padding-top: .5rem;
+  }
+
+  .md\:pr-xs {
+    padding-right: .5rem;
+  }
+
+  .md\:pb-xs {
+    padding-bottom: .5rem;
+  }
+
+  .md\:pl-xs {
+    padding-left: .5rem;
+  }
+
+  .md\:pt-s {
+    padding-top: .75rem;
+  }
+
+  .md\:pr-s {
+    padding-right: .75rem;
+  }
+
+  .md\:pb-s {
+    padding-bottom: .75rem;
+  }
+
+  .md\:pl-s {
+    padding-left: .75rem;
+  }
+
+  .md\:pt-m {
+    padding-top: 1rem;
+  }
+
+  .md\:pr-m {
+    padding-right: 1rem;
+  }
+
+  .md\:pb-m {
+    padding-bottom: 1rem;
+  }
+
+  .md\:pl-m {
+    padding-left: 1rem;
+  }
+
+  .md\:pt-l {
+    padding-top: 1.5rem;
+  }
+
+  .md\:pr-l {
+    padding-right: 1.5rem;
+  }
+
+  .md\:pb-l {
+    padding-bottom: 1.5rem;
+  }
+
+  .md\:pl-l {
+    padding-left: 1.5rem;
+  }
+
+  .md\:pt-xl {
+    padding-top: 2rem;
+  }
+
+  .md\:pr-xl {
+    padding-right: 2rem;
+  }
+
+  .md\:pb-xl {
+    padding-bottom: 2rem;
+  }
+
+  .md\:pl-xl {
+    padding-left: 2rem;
+  }
+
+  .md\:pt-xxl {
+    padding-top: 2.5rem;
+  }
+
+  .md\:pr-xxl {
+    padding-right: 2.5rem;
+  }
+
+  .md\:pb-xxl {
+    padding-bottom: 2.5rem;
+  }
+
+  .md\:pl-xxl {
+    padding-left: 2.5rem;
+  }
+
+  .md\:pt-3xl {
+    padding-top: 3rem;
+  }
+
+  .md\:pr-3xl {
+    padding-right: 3rem;
+  }
+
+  .md\:pb-3xl {
+    padding-bottom: 3rem;
+  }
+
+  .md\:pl-3xl {
+    padding-left: 3rem;
+  }
+
+  .md\:pt-4xl {
+    padding-top: 4rem;
+  }
+
+  .md\:pr-4xl {
+    padding-right: 4rem;
+  }
+
+  .md\:pb-4xl {
+    padding-bottom: 4rem;
+  }
+
+  .md\:pl-4xl {
+    padding-left: 4rem;
+  }
+
+  .md\:pt-5xl {
+    padding-top: 8rem;
+  }
+
+  .md\:pr-5xl {
+    padding-right: 8rem;
+  }
+
+  .md\:pb-5xl {
+    padding-bottom: 8rem;
+  }
+
+  .md\:pl-5xl {
+    padding-left: 8rem;
   }
 
   .md\:placeholder-primary::-moz-placeholder {
@@ -42927,6 +49835,83 @@ video {
     left: 0.875rem;
   }
 
+  .md\:inset-3xs {
+    top: .125rem;
+    right: .125rem;
+    bottom: .125rem;
+    left: .125rem;
+  }
+
+  .md\:inset-xxs {
+    top: .25rem;
+    right: .25rem;
+    bottom: .25rem;
+    left: .25rem;
+  }
+
+  .md\:inset-xs {
+    top: .5rem;
+    right: .5rem;
+    bottom: .5rem;
+    left: .5rem;
+  }
+
+  .md\:inset-s {
+    top: .75rem;
+    right: .75rem;
+    bottom: .75rem;
+    left: .75rem;
+  }
+
+  .md\:inset-m {
+    top: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    left: 1rem;
+  }
+
+  .md\:inset-l {
+    top: 1.5rem;
+    right: 1.5rem;
+    bottom: 1.5rem;
+    left: 1.5rem;
+  }
+
+  .md\:inset-xl {
+    top: 2rem;
+    right: 2rem;
+    bottom: 2rem;
+    left: 2rem;
+  }
+
+  .md\:inset-xxl {
+    top: 2.5rem;
+    right: 2.5rem;
+    bottom: 2.5rem;
+    left: 2.5rem;
+  }
+
+  .md\:inset-3xl {
+    top: 3rem;
+    right: 3rem;
+    bottom: 3rem;
+    left: 3rem;
+  }
+
+  .md\:inset-4xl {
+    top: 4rem;
+    right: 4rem;
+    bottom: 4rem;
+    left: 4rem;
+  }
+
+  .md\:inset-5xl {
+    top: 8rem;
+    right: 8rem;
+    bottom: 8rem;
+    left: 8rem;
+  }
+
   .md\:-inset-0 {
     top: 0px;
     right: 0px;
@@ -43170,6 +50155,83 @@ video {
     right: -0.875rem;
     bottom: -0.875rem;
     left: -0.875rem;
+  }
+
+  .md\:-inset-3xs {
+    top: -0.125rem;
+    right: -0.125rem;
+    bottom: -0.125rem;
+    left: -0.125rem;
+  }
+
+  .md\:-inset-xxs {
+    top: -0.25rem;
+    right: -0.25rem;
+    bottom: -0.25rem;
+    left: -0.25rem;
+  }
+
+  .md\:-inset-xs {
+    top: -0.5rem;
+    right: -0.5rem;
+    bottom: -0.5rem;
+    left: -0.5rem;
+  }
+
+  .md\:-inset-s {
+    top: -0.75rem;
+    right: -0.75rem;
+    bottom: -0.75rem;
+    left: -0.75rem;
+  }
+
+  .md\:-inset-m {
+    top: -1rem;
+    right: -1rem;
+    bottom: -1rem;
+    left: -1rem;
+  }
+
+  .md\:-inset-l {
+    top: -1.5rem;
+    right: -1.5rem;
+    bottom: -1.5rem;
+    left: -1.5rem;
+  }
+
+  .md\:-inset-xl {
+    top: -2rem;
+    right: -2rem;
+    bottom: -2rem;
+    left: -2rem;
+  }
+
+  .md\:-inset-xxl {
+    top: -2.5rem;
+    right: -2.5rem;
+    bottom: -2.5rem;
+    left: -2.5rem;
+  }
+
+  .md\:-inset-3xl {
+    top: -3rem;
+    right: -3rem;
+    bottom: -3rem;
+    left: -3rem;
+  }
+
+  .md\:-inset-4xl {
+    top: -4rem;
+    right: -4rem;
+    bottom: -4rem;
+    left: -4rem;
+  }
+
+  .md\:-inset-5xl {
+    top: -8rem;
+    right: -8rem;
+    bottom: -8rem;
+    left: -8rem;
   }
 
   .md\:inset-1\/2 {
@@ -43630,6 +50692,116 @@ video {
     left: 0.875rem;
   }
 
+  .md\:inset-y-3xs {
+    top: .125rem;
+    bottom: .125rem;
+  }
+
+  .md\:inset-x-3xs {
+    right: .125rem;
+    left: .125rem;
+  }
+
+  .md\:inset-y-xxs {
+    top: .25rem;
+    bottom: .25rem;
+  }
+
+  .md\:inset-x-xxs {
+    right: .25rem;
+    left: .25rem;
+  }
+
+  .md\:inset-y-xs {
+    top: .5rem;
+    bottom: .5rem;
+  }
+
+  .md\:inset-x-xs {
+    right: .5rem;
+    left: .5rem;
+  }
+
+  .md\:inset-y-s {
+    top: .75rem;
+    bottom: .75rem;
+  }
+
+  .md\:inset-x-s {
+    right: .75rem;
+    left: .75rem;
+  }
+
+  .md\:inset-y-m {
+    top: 1rem;
+    bottom: 1rem;
+  }
+
+  .md\:inset-x-m {
+    right: 1rem;
+    left: 1rem;
+  }
+
+  .md\:inset-y-l {
+    top: 1.5rem;
+    bottom: 1.5rem;
+  }
+
+  .md\:inset-x-l {
+    right: 1.5rem;
+    left: 1.5rem;
+  }
+
+  .md\:inset-y-xl {
+    top: 2rem;
+    bottom: 2rem;
+  }
+
+  .md\:inset-x-xl {
+    right: 2rem;
+    left: 2rem;
+  }
+
+  .md\:inset-y-xxl {
+    top: 2.5rem;
+    bottom: 2.5rem;
+  }
+
+  .md\:inset-x-xxl {
+    right: 2.5rem;
+    left: 2.5rem;
+  }
+
+  .md\:inset-y-3xl {
+    top: 3rem;
+    bottom: 3rem;
+  }
+
+  .md\:inset-x-3xl {
+    right: 3rem;
+    left: 3rem;
+  }
+
+  .md\:inset-y-4xl {
+    top: 4rem;
+    bottom: 4rem;
+  }
+
+  .md\:inset-x-4xl {
+    right: 4rem;
+    left: 4rem;
+  }
+
+  .md\:inset-y-5xl {
+    top: 8rem;
+    bottom: 8rem;
+  }
+
+  .md\:inset-x-5xl {
+    right: 8rem;
+    left: 8rem;
+  }
+
   .md\:-inset-y-0 {
     top: 0px;
     bottom: 0px;
@@ -43978,6 +51150,116 @@ video {
   .md\:-inset-x-3\.5 {
     right: -0.875rem;
     left: -0.875rem;
+  }
+
+  .md\:-inset-y-3xs {
+    top: -0.125rem;
+    bottom: -0.125rem;
+  }
+
+  .md\:-inset-x-3xs {
+    right: -0.125rem;
+    left: -0.125rem;
+  }
+
+  .md\:-inset-y-xxs {
+    top: -0.25rem;
+    bottom: -0.25rem;
+  }
+
+  .md\:-inset-x-xxs {
+    right: -0.25rem;
+    left: -0.25rem;
+  }
+
+  .md\:-inset-y-xs {
+    top: -0.5rem;
+    bottom: -0.5rem;
+  }
+
+  .md\:-inset-x-xs {
+    right: -0.5rem;
+    left: -0.5rem;
+  }
+
+  .md\:-inset-y-s {
+    top: -0.75rem;
+    bottom: -0.75rem;
+  }
+
+  .md\:-inset-x-s {
+    right: -0.75rem;
+    left: -0.75rem;
+  }
+
+  .md\:-inset-y-m {
+    top: -1rem;
+    bottom: -1rem;
+  }
+
+  .md\:-inset-x-m {
+    right: -1rem;
+    left: -1rem;
+  }
+
+  .md\:-inset-y-l {
+    top: -1.5rem;
+    bottom: -1.5rem;
+  }
+
+  .md\:-inset-x-l {
+    right: -1.5rem;
+    left: -1.5rem;
+  }
+
+  .md\:-inset-y-xl {
+    top: -2rem;
+    bottom: -2rem;
+  }
+
+  .md\:-inset-x-xl {
+    right: -2rem;
+    left: -2rem;
+  }
+
+  .md\:-inset-y-xxl {
+    top: -2.5rem;
+    bottom: -2.5rem;
+  }
+
+  .md\:-inset-x-xxl {
+    right: -2.5rem;
+    left: -2.5rem;
+  }
+
+  .md\:-inset-y-3xl {
+    top: -3rem;
+    bottom: -3rem;
+  }
+
+  .md\:-inset-x-3xl {
+    right: -3rem;
+    left: -3rem;
+  }
+
+  .md\:-inset-y-4xl {
+    top: -4rem;
+    bottom: -4rem;
+  }
+
+  .md\:-inset-x-4xl {
+    right: -4rem;
+    left: -4rem;
+  }
+
+  .md\:-inset-y-5xl {
+    top: -8rem;
+    bottom: -8rem;
+  }
+
+  .md\:-inset-x-5xl {
+    right: -8rem;
+    left: -8rem;
   }
 
   .md\:inset-y-1\/2 {
@@ -44696,6 +51978,182 @@ video {
     left: 0.875rem;
   }
 
+  .md\:top-3xs {
+    top: .125rem;
+  }
+
+  .md\:right-3xs {
+    right: .125rem;
+  }
+
+  .md\:bottom-3xs {
+    bottom: .125rem;
+  }
+
+  .md\:left-3xs {
+    left: .125rem;
+  }
+
+  .md\:top-xxs {
+    top: .25rem;
+  }
+
+  .md\:right-xxs {
+    right: .25rem;
+  }
+
+  .md\:bottom-xxs {
+    bottom: .25rem;
+  }
+
+  .md\:left-xxs {
+    left: .25rem;
+  }
+
+  .md\:top-xs {
+    top: .5rem;
+  }
+
+  .md\:right-xs {
+    right: .5rem;
+  }
+
+  .md\:bottom-xs {
+    bottom: .5rem;
+  }
+
+  .md\:left-xs {
+    left: .5rem;
+  }
+
+  .md\:top-s {
+    top: .75rem;
+  }
+
+  .md\:right-s {
+    right: .75rem;
+  }
+
+  .md\:bottom-s {
+    bottom: .75rem;
+  }
+
+  .md\:left-s {
+    left: .75rem;
+  }
+
+  .md\:top-m {
+    top: 1rem;
+  }
+
+  .md\:right-m {
+    right: 1rem;
+  }
+
+  .md\:bottom-m {
+    bottom: 1rem;
+  }
+
+  .md\:left-m {
+    left: 1rem;
+  }
+
+  .md\:top-l {
+    top: 1.5rem;
+  }
+
+  .md\:right-l {
+    right: 1.5rem;
+  }
+
+  .md\:bottom-l {
+    bottom: 1.5rem;
+  }
+
+  .md\:left-l {
+    left: 1.5rem;
+  }
+
+  .md\:top-xl {
+    top: 2rem;
+  }
+
+  .md\:right-xl {
+    right: 2rem;
+  }
+
+  .md\:bottom-xl {
+    bottom: 2rem;
+  }
+
+  .md\:left-xl {
+    left: 2rem;
+  }
+
+  .md\:top-xxl {
+    top: 2.5rem;
+  }
+
+  .md\:right-xxl {
+    right: 2.5rem;
+  }
+
+  .md\:bottom-xxl {
+    bottom: 2.5rem;
+  }
+
+  .md\:left-xxl {
+    left: 2.5rem;
+  }
+
+  .md\:top-3xl {
+    top: 3rem;
+  }
+
+  .md\:right-3xl {
+    right: 3rem;
+  }
+
+  .md\:bottom-3xl {
+    bottom: 3rem;
+  }
+
+  .md\:left-3xl {
+    left: 3rem;
+  }
+
+  .md\:top-4xl {
+    top: 4rem;
+  }
+
+  .md\:right-4xl {
+    right: 4rem;
+  }
+
+  .md\:bottom-4xl {
+    bottom: 4rem;
+  }
+
+  .md\:left-4xl {
+    left: 4rem;
+  }
+
+  .md\:top-5xl {
+    top: 8rem;
+  }
+
+  .md\:right-5xl {
+    right: 8rem;
+  }
+
+  .md\:bottom-5xl {
+    bottom: 8rem;
+  }
+
+  .md\:left-5xl {
+    left: 8rem;
+  }
+
   .md\:-top-0 {
     top: 0px;
   }
@@ -45254,6 +52712,182 @@ video {
 
   .md\:-left-3\.5 {
     left: -0.875rem;
+  }
+
+  .md\:-top-3xs {
+    top: -0.125rem;
+  }
+
+  .md\:-right-3xs {
+    right: -0.125rem;
+  }
+
+  .md\:-bottom-3xs {
+    bottom: -0.125rem;
+  }
+
+  .md\:-left-3xs {
+    left: -0.125rem;
+  }
+
+  .md\:-top-xxs {
+    top: -0.25rem;
+  }
+
+  .md\:-right-xxs {
+    right: -0.25rem;
+  }
+
+  .md\:-bottom-xxs {
+    bottom: -0.25rem;
+  }
+
+  .md\:-left-xxs {
+    left: -0.25rem;
+  }
+
+  .md\:-top-xs {
+    top: -0.5rem;
+  }
+
+  .md\:-right-xs {
+    right: -0.5rem;
+  }
+
+  .md\:-bottom-xs {
+    bottom: -0.5rem;
+  }
+
+  .md\:-left-xs {
+    left: -0.5rem;
+  }
+
+  .md\:-top-s {
+    top: -0.75rem;
+  }
+
+  .md\:-right-s {
+    right: -0.75rem;
+  }
+
+  .md\:-bottom-s {
+    bottom: -0.75rem;
+  }
+
+  .md\:-left-s {
+    left: -0.75rem;
+  }
+
+  .md\:-top-m {
+    top: -1rem;
+  }
+
+  .md\:-right-m {
+    right: -1rem;
+  }
+
+  .md\:-bottom-m {
+    bottom: -1rem;
+  }
+
+  .md\:-left-m {
+    left: -1rem;
+  }
+
+  .md\:-top-l {
+    top: -1.5rem;
+  }
+
+  .md\:-right-l {
+    right: -1.5rem;
+  }
+
+  .md\:-bottom-l {
+    bottom: -1.5rem;
+  }
+
+  .md\:-left-l {
+    left: -1.5rem;
+  }
+
+  .md\:-top-xl {
+    top: -2rem;
+  }
+
+  .md\:-right-xl {
+    right: -2rem;
+  }
+
+  .md\:-bottom-xl {
+    bottom: -2rem;
+  }
+
+  .md\:-left-xl {
+    left: -2rem;
+  }
+
+  .md\:-top-xxl {
+    top: -2.5rem;
+  }
+
+  .md\:-right-xxl {
+    right: -2.5rem;
+  }
+
+  .md\:-bottom-xxl {
+    bottom: -2.5rem;
+  }
+
+  .md\:-left-xxl {
+    left: -2.5rem;
+  }
+
+  .md\:-top-3xl {
+    top: -3rem;
+  }
+
+  .md\:-right-3xl {
+    right: -3rem;
+  }
+
+  .md\:-bottom-3xl {
+    bottom: -3rem;
+  }
+
+  .md\:-left-3xl {
+    left: -3rem;
+  }
+
+  .md\:-top-4xl {
+    top: -4rem;
+  }
+
+  .md\:-right-4xl {
+    right: -4rem;
+  }
+
+  .md\:-bottom-4xl {
+    bottom: -4rem;
+  }
+
+  .md\:-left-4xl {
+    left: -4rem;
+  }
+
+  .md\:-top-5xl {
+    top: -8rem;
+  }
+
+  .md\:-right-5xl {
+    right: -8rem;
+  }
+
+  .md\:-bottom-5xl {
+    bottom: -8rem;
+  }
+
+  .md\:-left-5xl {
+    left: -8rem;
   }
 
   .md\:top-1\/2 {
@@ -47129,6 +54763,50 @@ video {
     width: 0.875rem;
   }
 
+  .md\:w-3xs {
+    width: .125rem;
+  }
+
+  .md\:w-xxs {
+    width: .25rem;
+  }
+
+  .md\:w-xs {
+    width: .5rem;
+  }
+
+  .md\:w-s {
+    width: .75rem;
+  }
+
+  .md\:w-m {
+    width: 1rem;
+  }
+
+  .md\:w-l {
+    width: 1.5rem;
+  }
+
+  .md\:w-xl {
+    width: 2rem;
+  }
+
+  .md\:w-xxl {
+    width: 2.5rem;
+  }
+
+  .md\:w-3xl {
+    width: 3rem;
+  }
+
+  .md\:w-4xl {
+    width: 4rem;
+  }
+
+  .md\:w-5xl {
+    width: 8rem;
+  }
+
   .md\:w-1\/2 {
     width: 50%;
   }
@@ -47477,6 +55155,50 @@ video {
     gap: 0.875rem;
   }
 
+  .md\:gap-3xs {
+    gap: .125rem;
+  }
+
+  .md\:gap-xxs {
+    gap: .25rem;
+  }
+
+  .md\:gap-xs {
+    gap: .5rem;
+  }
+
+  .md\:gap-s {
+    gap: .75rem;
+  }
+
+  .md\:gap-m {
+    gap: 1rem;
+  }
+
+  .md\:gap-l {
+    gap: 1.5rem;
+  }
+
+  .md\:gap-xl {
+    gap: 2rem;
+  }
+
+  .md\:gap-xxl {
+    gap: 2.5rem;
+  }
+
+  .md\:gap-3xl {
+    gap: 3rem;
+  }
+
+  .md\:gap-4xl {
+    gap: 4rem;
+  }
+
+  .md\:gap-5xl {
+    gap: 8rem;
+  }
+
   .md\:gap-x-0 {
     -moz-column-gap: 0px;
          column-gap: 0px;
@@ -47652,6 +55374,61 @@ video {
          column-gap: 0.875rem;
   }
 
+  .md\:gap-x-3xs {
+    -moz-column-gap: .125rem;
+         column-gap: .125rem;
+  }
+
+  .md\:gap-x-xxs {
+    -moz-column-gap: .25rem;
+         column-gap: .25rem;
+  }
+
+  .md\:gap-x-xs {
+    -moz-column-gap: .5rem;
+         column-gap: .5rem;
+  }
+
+  .md\:gap-x-s {
+    -moz-column-gap: .75rem;
+         column-gap: .75rem;
+  }
+
+  .md\:gap-x-m {
+    -moz-column-gap: 1rem;
+         column-gap: 1rem;
+  }
+
+  .md\:gap-x-l {
+    -moz-column-gap: 1.5rem;
+         column-gap: 1.5rem;
+  }
+
+  .md\:gap-x-xl {
+    -moz-column-gap: 2rem;
+         column-gap: 2rem;
+  }
+
+  .md\:gap-x-xxl {
+    -moz-column-gap: 2.5rem;
+         column-gap: 2.5rem;
+  }
+
+  .md\:gap-x-3xl {
+    -moz-column-gap: 3rem;
+         column-gap: 3rem;
+  }
+
+  .md\:gap-x-4xl {
+    -moz-column-gap: 4rem;
+         column-gap: 4rem;
+  }
+
+  .md\:gap-x-5xl {
+    -moz-column-gap: 8rem;
+         column-gap: 8rem;
+  }
+
   .md\:gap-y-0 {
     row-gap: 0px;
   }
@@ -47790,6 +55567,50 @@ video {
 
   .md\:gap-y-3\.5 {
     row-gap: 0.875rem;
+  }
+
+  .md\:gap-y-3xs {
+    row-gap: .125rem;
+  }
+
+  .md\:gap-y-xxs {
+    row-gap: .25rem;
+  }
+
+  .md\:gap-y-xs {
+    row-gap: .5rem;
+  }
+
+  .md\:gap-y-s {
+    row-gap: .75rem;
+  }
+
+  .md\:gap-y-m {
+    row-gap: 1rem;
+  }
+
+  .md\:gap-y-l {
+    row-gap: 1.5rem;
+  }
+
+  .md\:gap-y-xl {
+    row-gap: 2rem;
+  }
+
+  .md\:gap-y-xxl {
+    row-gap: 2.5rem;
+  }
+
+  .md\:gap-y-3xl {
+    row-gap: 3rem;
+  }
+
+  .md\:gap-y-4xl {
+    row-gap: 4rem;
+  }
+
+  .md\:gap-y-5xl {
+    row-gap: 8rem;
   }
 
   .md\:grid-flow-row {
@@ -48984,6 +56805,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .md\:translate-x-3xs {
+    --tw-translate-x: .125rem;
+  }
+
+  .md\:translate-x-xxs {
+    --tw-translate-x: .25rem;
+  }
+
+  .md\:translate-x-xs {
+    --tw-translate-x: .5rem;
+  }
+
+  .md\:translate-x-s {
+    --tw-translate-x: .75rem;
+  }
+
+  .md\:translate-x-m {
+    --tw-translate-x: 1rem;
+  }
+
+  .md\:translate-x-l {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .md\:translate-x-xl {
+    --tw-translate-x: 2rem;
+  }
+
+  .md\:translate-x-xxl {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .md\:translate-x-3xl {
+    --tw-translate-x: 3rem;
+  }
+
+  .md\:translate-x-4xl {
+    --tw-translate-x: 4rem;
+  }
+
+  .md\:translate-x-5xl {
+    --tw-translate-x: 8rem;
+  }
+
   .md\:-translate-x-0 {
     --tw-translate-x: 0px;
   }
@@ -49122,6 +56987,50 @@ video {
 
   .md\:-translate-x-3\.5 {
     --tw-translate-x: -0.875rem;
+  }
+
+  .md\:-translate-x-3xs {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .md\:-translate-x-xxs {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .md\:-translate-x-xs {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .md\:-translate-x-s {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .md\:-translate-x-m {
+    --tw-translate-x: -1rem;
+  }
+
+  .md\:-translate-x-l {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .md\:-translate-x-xl {
+    --tw-translate-x: -2rem;
+  }
+
+  .md\:-translate-x-xxl {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .md\:-translate-x-3xl {
+    --tw-translate-x: -3rem;
+  }
+
+  .md\:-translate-x-4xl {
+    --tw-translate-x: -4rem;
+  }
+
+  .md\:-translate-x-5xl {
+    --tw-translate-x: -8rem;
   }
 
   .md\:translate-x-1\/2 {
@@ -49320,6 +57229,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .md\:translate-y-3xs {
+    --tw-translate-y: .125rem;
+  }
+
+  .md\:translate-y-xxs {
+    --tw-translate-y: .25rem;
+  }
+
+  .md\:translate-y-xs {
+    --tw-translate-y: .5rem;
+  }
+
+  .md\:translate-y-s {
+    --tw-translate-y: .75rem;
+  }
+
+  .md\:translate-y-m {
+    --tw-translate-y: 1rem;
+  }
+
+  .md\:translate-y-l {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .md\:translate-y-xl {
+    --tw-translate-y: 2rem;
+  }
+
+  .md\:translate-y-xxl {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .md\:translate-y-3xl {
+    --tw-translate-y: 3rem;
+  }
+
+  .md\:translate-y-4xl {
+    --tw-translate-y: 4rem;
+  }
+
+  .md\:translate-y-5xl {
+    --tw-translate-y: 8rem;
+  }
+
   .md\:-translate-y-0 {
     --tw-translate-y: 0px;
   }
@@ -49458,6 +57411,50 @@ video {
 
   .md\:-translate-y-3\.5 {
     --tw-translate-y: -0.875rem;
+  }
+
+  .md\:-translate-y-3xs {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .md\:-translate-y-xxs {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .md\:-translate-y-xs {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .md\:-translate-y-s {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .md\:-translate-y-m {
+    --tw-translate-y: -1rem;
+  }
+
+  .md\:-translate-y-l {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .md\:-translate-y-xl {
+    --tw-translate-y: -2rem;
+  }
+
+  .md\:-translate-y-xxl {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .md\:-translate-y-3xl {
+    --tw-translate-y: -3rem;
+  }
+
+  .md\:-translate-y-4xl {
+    --tw-translate-y: -4rem;
+  }
+
+  .md\:-translate-y-5xl {
+    --tw-translate-y: -8rem;
   }
 
   .md\:translate-y-1\/2 {
@@ -49656,6 +57653,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .md\:hover\:translate-x-3xs:hover {
+    --tw-translate-x: .125rem;
+  }
+
+  .md\:hover\:translate-x-xxs:hover {
+    --tw-translate-x: .25rem;
+  }
+
+  .md\:hover\:translate-x-xs:hover {
+    --tw-translate-x: .5rem;
+  }
+
+  .md\:hover\:translate-x-s:hover {
+    --tw-translate-x: .75rem;
+  }
+
+  .md\:hover\:translate-x-m:hover {
+    --tw-translate-x: 1rem;
+  }
+
+  .md\:hover\:translate-x-l:hover {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .md\:hover\:translate-x-xl:hover {
+    --tw-translate-x: 2rem;
+  }
+
+  .md\:hover\:translate-x-xxl:hover {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .md\:hover\:translate-x-3xl:hover {
+    --tw-translate-x: 3rem;
+  }
+
+  .md\:hover\:translate-x-4xl:hover {
+    --tw-translate-x: 4rem;
+  }
+
+  .md\:hover\:translate-x-5xl:hover {
+    --tw-translate-x: 8rem;
+  }
+
   .md\:hover\:-translate-x-0:hover {
     --tw-translate-x: 0px;
   }
@@ -49794,6 +57835,50 @@ video {
 
   .md\:hover\:-translate-x-3\.5:hover {
     --tw-translate-x: -0.875rem;
+  }
+
+  .md\:hover\:-translate-x-3xs:hover {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .md\:hover\:-translate-x-xxs:hover {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .md\:hover\:-translate-x-xs:hover {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .md\:hover\:-translate-x-s:hover {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .md\:hover\:-translate-x-m:hover {
+    --tw-translate-x: -1rem;
+  }
+
+  .md\:hover\:-translate-x-l:hover {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .md\:hover\:-translate-x-xl:hover {
+    --tw-translate-x: -2rem;
+  }
+
+  .md\:hover\:-translate-x-xxl:hover {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .md\:hover\:-translate-x-3xl:hover {
+    --tw-translate-x: -3rem;
+  }
+
+  .md\:hover\:-translate-x-4xl:hover {
+    --tw-translate-x: -4rem;
+  }
+
+  .md\:hover\:-translate-x-5xl:hover {
+    --tw-translate-x: -8rem;
   }
 
   .md\:hover\:translate-x-1\/2:hover {
@@ -49992,6 +58077,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .md\:hover\:translate-y-3xs:hover {
+    --tw-translate-y: .125rem;
+  }
+
+  .md\:hover\:translate-y-xxs:hover {
+    --tw-translate-y: .25rem;
+  }
+
+  .md\:hover\:translate-y-xs:hover {
+    --tw-translate-y: .5rem;
+  }
+
+  .md\:hover\:translate-y-s:hover {
+    --tw-translate-y: .75rem;
+  }
+
+  .md\:hover\:translate-y-m:hover {
+    --tw-translate-y: 1rem;
+  }
+
+  .md\:hover\:translate-y-l:hover {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .md\:hover\:translate-y-xl:hover {
+    --tw-translate-y: 2rem;
+  }
+
+  .md\:hover\:translate-y-xxl:hover {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .md\:hover\:translate-y-3xl:hover {
+    --tw-translate-y: 3rem;
+  }
+
+  .md\:hover\:translate-y-4xl:hover {
+    --tw-translate-y: 4rem;
+  }
+
+  .md\:hover\:translate-y-5xl:hover {
+    --tw-translate-y: 8rem;
+  }
+
   .md\:hover\:-translate-y-0:hover {
     --tw-translate-y: 0px;
   }
@@ -50130,6 +58259,50 @@ video {
 
   .md\:hover\:-translate-y-3\.5:hover {
     --tw-translate-y: -0.875rem;
+  }
+
+  .md\:hover\:-translate-y-3xs:hover {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .md\:hover\:-translate-y-xxs:hover {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .md\:hover\:-translate-y-xs:hover {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .md\:hover\:-translate-y-s:hover {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .md\:hover\:-translate-y-m:hover {
+    --tw-translate-y: -1rem;
+  }
+
+  .md\:hover\:-translate-y-l:hover {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .md\:hover\:-translate-y-xl:hover {
+    --tw-translate-y: -2rem;
+  }
+
+  .md\:hover\:-translate-y-xxl:hover {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .md\:hover\:-translate-y-3xl:hover {
+    --tw-translate-y: -3rem;
+  }
+
+  .md\:hover\:-translate-y-4xl:hover {
+    --tw-translate-y: -4rem;
+  }
+
+  .md\:hover\:-translate-y-5xl:hover {
+    --tw-translate-y: -8rem;
   }
 
   .md\:hover\:translate-y-1\/2:hover {
@@ -50328,6 +58501,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .md\:focus\:translate-x-3xs:focus {
+    --tw-translate-x: .125rem;
+  }
+
+  .md\:focus\:translate-x-xxs:focus {
+    --tw-translate-x: .25rem;
+  }
+
+  .md\:focus\:translate-x-xs:focus {
+    --tw-translate-x: .5rem;
+  }
+
+  .md\:focus\:translate-x-s:focus {
+    --tw-translate-x: .75rem;
+  }
+
+  .md\:focus\:translate-x-m:focus {
+    --tw-translate-x: 1rem;
+  }
+
+  .md\:focus\:translate-x-l:focus {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .md\:focus\:translate-x-xl:focus {
+    --tw-translate-x: 2rem;
+  }
+
+  .md\:focus\:translate-x-xxl:focus {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .md\:focus\:translate-x-3xl:focus {
+    --tw-translate-x: 3rem;
+  }
+
+  .md\:focus\:translate-x-4xl:focus {
+    --tw-translate-x: 4rem;
+  }
+
+  .md\:focus\:translate-x-5xl:focus {
+    --tw-translate-x: 8rem;
+  }
+
   .md\:focus\:-translate-x-0:focus {
     --tw-translate-x: 0px;
   }
@@ -50466,6 +58683,50 @@ video {
 
   .md\:focus\:-translate-x-3\.5:focus {
     --tw-translate-x: -0.875rem;
+  }
+
+  .md\:focus\:-translate-x-3xs:focus {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .md\:focus\:-translate-x-xxs:focus {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .md\:focus\:-translate-x-xs:focus {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .md\:focus\:-translate-x-s:focus {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .md\:focus\:-translate-x-m:focus {
+    --tw-translate-x: -1rem;
+  }
+
+  .md\:focus\:-translate-x-l:focus {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .md\:focus\:-translate-x-xl:focus {
+    --tw-translate-x: -2rem;
+  }
+
+  .md\:focus\:-translate-x-xxl:focus {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .md\:focus\:-translate-x-3xl:focus {
+    --tw-translate-x: -3rem;
+  }
+
+  .md\:focus\:-translate-x-4xl:focus {
+    --tw-translate-x: -4rem;
+  }
+
+  .md\:focus\:-translate-x-5xl:focus {
+    --tw-translate-x: -8rem;
   }
 
   .md\:focus\:translate-x-1\/2:focus {
@@ -50664,6 +58925,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .md\:focus\:translate-y-3xs:focus {
+    --tw-translate-y: .125rem;
+  }
+
+  .md\:focus\:translate-y-xxs:focus {
+    --tw-translate-y: .25rem;
+  }
+
+  .md\:focus\:translate-y-xs:focus {
+    --tw-translate-y: .5rem;
+  }
+
+  .md\:focus\:translate-y-s:focus {
+    --tw-translate-y: .75rem;
+  }
+
+  .md\:focus\:translate-y-m:focus {
+    --tw-translate-y: 1rem;
+  }
+
+  .md\:focus\:translate-y-l:focus {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .md\:focus\:translate-y-xl:focus {
+    --tw-translate-y: 2rem;
+  }
+
+  .md\:focus\:translate-y-xxl:focus {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .md\:focus\:translate-y-3xl:focus {
+    --tw-translate-y: 3rem;
+  }
+
+  .md\:focus\:translate-y-4xl:focus {
+    --tw-translate-y: 4rem;
+  }
+
+  .md\:focus\:translate-y-5xl:focus {
+    --tw-translate-y: 8rem;
+  }
+
   .md\:focus\:-translate-y-0:focus {
     --tw-translate-y: 0px;
   }
@@ -50802,6 +59107,50 @@ video {
 
   .md\:focus\:-translate-y-3\.5:focus {
     --tw-translate-y: -0.875rem;
+  }
+
+  .md\:focus\:-translate-y-3xs:focus {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .md\:focus\:-translate-y-xxs:focus {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .md\:focus\:-translate-y-xs:focus {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .md\:focus\:-translate-y-s:focus {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .md\:focus\:-translate-y-m:focus {
+    --tw-translate-y: -1rem;
+  }
+
+  .md\:focus\:-translate-y-l:focus {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .md\:focus\:-translate-y-xl:focus {
+    --tw-translate-y: -2rem;
+  }
+
+  .md\:focus\:-translate-y-xxl:focus {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .md\:focus\:-translate-y-3xl:focus {
+    --tw-translate-y: -3rem;
+  }
+
+  .md\:focus\:-translate-y-4xl:focus {
+    --tw-translate-y: -4rem;
+  }
+
+  .md\:focus\:-translate-y-5xl:focus {
+    --tw-translate-y: -8rem;
   }
 
   .md\:focus\:translate-y-1\/2:focus {
@@ -51725,6 +60074,138 @@ video {
     margin-left: calc(0.875rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
+  .lg\:space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.125rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.125rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.125rem * var(--tw-space-x-reverse));
+    margin-left: calc(.125rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.25rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.25rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-y-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.5rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-y-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.75rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.75rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-y-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1rem * var(--tw-space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-y-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-y-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2rem * var(--tw-space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(2.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(2.5rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(3rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(3rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(3rem * var(--tw-space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(4rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(4rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(4rem * var(--tw-space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(8rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(8rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(8rem * var(--tw-space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
   .lg\:-space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
@@ -52143,6 +60624,138 @@ video {
     --tw-space-x-reverse: 0;
     margin-right: calc(-0.875rem * var(--tw-space-x-reverse));
     margin-left: calc(-0.875rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.125rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.125rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.125rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.25rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.25rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.5rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.75rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.75rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-1rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-1rem * var(--tw-space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-1.5rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-2rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-2rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-2rem * var(--tw-space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-2.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-2.5rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-3rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-3rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-3rem * var(--tw-space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-4rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-4rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-4rem * var(--tw-space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:-space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-8rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-8rem * var(--tw-space-y-reverse));
+  }
+
+  .lg\:-space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-8rem * var(--tw-space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .lg\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -54801,6 +63414,50 @@ video {
     height: 0.875rem;
   }
 
+  .lg\:h-3xs {
+    height: .125rem;
+  }
+
+  .lg\:h-xxs {
+    height: .25rem;
+  }
+
+  .lg\:h-xs {
+    height: .5rem;
+  }
+
+  .lg\:h-s {
+    height: .75rem;
+  }
+
+  .lg\:h-m {
+    height: 1rem;
+  }
+
+  .lg\:h-l {
+    height: 1.5rem;
+  }
+
+  .lg\:h-xl {
+    height: 2rem;
+  }
+
+  .lg\:h-xxl {
+    height: 2.5rem;
+  }
+
+  .lg\:h-3xl {
+    height: 3rem;
+  }
+
+  .lg\:h-4xl {
+    height: 4rem;
+  }
+
+  .lg\:h-5xl {
+    height: 8rem;
+  }
+
   .lg\:h-1\/2 {
     height: 50%;
   }
@@ -55117,6 +63774,50 @@ video {
     margin: 0.875rem;
   }
 
+  .lg\:m-3xs {
+    margin: .125rem;
+  }
+
+  .lg\:m-xxs {
+    margin: .25rem;
+  }
+
+  .lg\:m-xs {
+    margin: .5rem;
+  }
+
+  .lg\:m-s {
+    margin: .75rem;
+  }
+
+  .lg\:m-m {
+    margin: 1rem;
+  }
+
+  .lg\:m-l {
+    margin: 1.5rem;
+  }
+
+  .lg\:m-xl {
+    margin: 2rem;
+  }
+
+  .lg\:m-xxl {
+    margin: 2.5rem;
+  }
+
+  .lg\:m-3xl {
+    margin: 3rem;
+  }
+
+  .lg\:m-4xl {
+    margin: 4rem;
+  }
+
+  .lg\:m-5xl {
+    margin: 8rem;
+  }
+
   .lg\:-m-0 {
     margin: 0px;
   }
@@ -55255,6 +63956,50 @@ video {
 
   .lg\:-m-3\.5 {
     margin: -0.875rem;
+  }
+
+  .lg\:-m-3xs {
+    margin: -0.125rem;
+  }
+
+  .lg\:-m-xxs {
+    margin: -0.25rem;
+  }
+
+  .lg\:-m-xs {
+    margin: -0.5rem;
+  }
+
+  .lg\:-m-s {
+    margin: -0.75rem;
+  }
+
+  .lg\:-m-m {
+    margin: -1rem;
+  }
+
+  .lg\:-m-l {
+    margin: -1.5rem;
+  }
+
+  .lg\:-m-xl {
+    margin: -2rem;
+  }
+
+  .lg\:-m-xxl {
+    margin: -2.5rem;
+  }
+
+  .lg\:-m-3xl {
+    margin: -3rem;
+  }
+
+  .lg\:-m-4xl {
+    margin: -4rem;
+  }
+
+  .lg\:-m-5xl {
+    margin: -8rem;
   }
 
   .lg\:my-0 {
@@ -55617,6 +64362,116 @@ video {
     margin-right: 0.875rem;
   }
 
+  .lg\:my-3xs {
+    margin-top: .125rem;
+    margin-bottom: .125rem;
+  }
+
+  .lg\:mx-3xs {
+    margin-left: .125rem;
+    margin-right: .125rem;
+  }
+
+  .lg\:my-xxs {
+    margin-top: .25rem;
+    margin-bottom: .25rem;
+  }
+
+  .lg\:mx-xxs {
+    margin-left: .25rem;
+    margin-right: .25rem;
+  }
+
+  .lg\:my-xs {
+    margin-top: .5rem;
+    margin-bottom: .5rem;
+  }
+
+  .lg\:mx-xs {
+    margin-left: .5rem;
+    margin-right: .5rem;
+  }
+
+  .lg\:my-s {
+    margin-top: .75rem;
+    margin-bottom: .75rem;
+  }
+
+  .lg\:mx-s {
+    margin-left: .75rem;
+    margin-right: .75rem;
+  }
+
+  .lg\:my-m {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .lg\:mx-m {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+
+  .lg\:my-l {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .lg\:mx-l {
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+
+  .lg\:my-xl {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .lg\:mx-xl {
+    margin-left: 2rem;
+    margin-right: 2rem;
+  }
+
+  .lg\:my-xxl {
+    margin-top: 2.5rem;
+    margin-bottom: 2.5rem;
+  }
+
+  .lg\:mx-xxl {
+    margin-left: 2.5rem;
+    margin-right: 2.5rem;
+  }
+
+  .lg\:my-3xl {
+    margin-top: 3rem;
+    margin-bottom: 3rem;
+  }
+
+  .lg\:mx-3xl {
+    margin-left: 3rem;
+    margin-right: 3rem;
+  }
+
+  .lg\:my-4xl {
+    margin-top: 4rem;
+    margin-bottom: 4rem;
+  }
+
+  .lg\:mx-4xl {
+    margin-left: 4rem;
+    margin-right: 4rem;
+  }
+
+  .lg\:my-5xl {
+    margin-top: 8rem;
+    margin-bottom: 8rem;
+  }
+
+  .lg\:mx-5xl {
+    margin-left: 8rem;
+    margin-right: 8rem;
+  }
+
   .lg\:-my-0 {
     margin-top: 0px;
     margin-bottom: 0px;
@@ -55965,6 +64820,116 @@ video {
   .lg\:-mx-3\.5 {
     margin-left: -0.875rem;
     margin-right: -0.875rem;
+  }
+
+  .lg\:-my-3xs {
+    margin-top: -0.125rem;
+    margin-bottom: -0.125rem;
+  }
+
+  .lg\:-mx-3xs {
+    margin-left: -0.125rem;
+    margin-right: -0.125rem;
+  }
+
+  .lg\:-my-xxs {
+    margin-top: -0.25rem;
+    margin-bottom: -0.25rem;
+  }
+
+  .lg\:-mx-xxs {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+  }
+
+  .lg\:-my-xs {
+    margin-top: -0.5rem;
+    margin-bottom: -0.5rem;
+  }
+
+  .lg\:-mx-xs {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+  }
+
+  .lg\:-my-s {
+    margin-top: -0.75rem;
+    margin-bottom: -0.75rem;
+  }
+
+  .lg\:-mx-s {
+    margin-left: -0.75rem;
+    margin-right: -0.75rem;
+  }
+
+  .lg\:-my-m {
+    margin-top: -1rem;
+    margin-bottom: -1rem;
+  }
+
+  .lg\:-mx-m {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+
+  .lg\:-my-l {
+    margin-top: -1.5rem;
+    margin-bottom: -1.5rem;
+  }
+
+  .lg\:-mx-l {
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+  }
+
+  .lg\:-my-xl {
+    margin-top: -2rem;
+    margin-bottom: -2rem;
+  }
+
+  .lg\:-mx-xl {
+    margin-left: -2rem;
+    margin-right: -2rem;
+  }
+
+  .lg\:-my-xxl {
+    margin-top: -2.5rem;
+    margin-bottom: -2.5rem;
+  }
+
+  .lg\:-mx-xxl {
+    margin-left: -2.5rem;
+    margin-right: -2.5rem;
+  }
+
+  .lg\:-my-3xl {
+    margin-top: -3rem;
+    margin-bottom: -3rem;
+  }
+
+  .lg\:-mx-3xl {
+    margin-left: -3rem;
+    margin-right: -3rem;
+  }
+
+  .lg\:-my-4xl {
+    margin-top: -4rem;
+    margin-bottom: -4rem;
+  }
+
+  .lg\:-mx-4xl {
+    margin-left: -4rem;
+    margin-right: -4rem;
+  }
+
+  .lg\:-my-5xl {
+    margin-top: -8rem;
+    margin-bottom: -8rem;
+  }
+
+  .lg\:-mx-5xl {
+    margin-left: -8rem;
+    margin-right: -8rem;
   }
 
   .lg\:mt-0 {
@@ -56543,6 +65508,182 @@ video {
     margin-left: 0.875rem;
   }
 
+  .lg\:mt-3xs {
+    margin-top: .125rem;
+  }
+
+  .lg\:mr-3xs {
+    margin-right: .125rem;
+  }
+
+  .lg\:mb-3xs {
+    margin-bottom: .125rem;
+  }
+
+  .lg\:ml-3xs {
+    margin-left: .125rem;
+  }
+
+  .lg\:mt-xxs {
+    margin-top: .25rem;
+  }
+
+  .lg\:mr-xxs {
+    margin-right: .25rem;
+  }
+
+  .lg\:mb-xxs {
+    margin-bottom: .25rem;
+  }
+
+  .lg\:ml-xxs {
+    margin-left: .25rem;
+  }
+
+  .lg\:mt-xs {
+    margin-top: .5rem;
+  }
+
+  .lg\:mr-xs {
+    margin-right: .5rem;
+  }
+
+  .lg\:mb-xs {
+    margin-bottom: .5rem;
+  }
+
+  .lg\:ml-xs {
+    margin-left: .5rem;
+  }
+
+  .lg\:mt-s {
+    margin-top: .75rem;
+  }
+
+  .lg\:mr-s {
+    margin-right: .75rem;
+  }
+
+  .lg\:mb-s {
+    margin-bottom: .75rem;
+  }
+
+  .lg\:ml-s {
+    margin-left: .75rem;
+  }
+
+  .lg\:mt-m {
+    margin-top: 1rem;
+  }
+
+  .lg\:mr-m {
+    margin-right: 1rem;
+  }
+
+  .lg\:mb-m {
+    margin-bottom: 1rem;
+  }
+
+  .lg\:ml-m {
+    margin-left: 1rem;
+  }
+
+  .lg\:mt-l {
+    margin-top: 1.5rem;
+  }
+
+  .lg\:mr-l {
+    margin-right: 1.5rem;
+  }
+
+  .lg\:mb-l {
+    margin-bottom: 1.5rem;
+  }
+
+  .lg\:ml-l {
+    margin-left: 1.5rem;
+  }
+
+  .lg\:mt-xl {
+    margin-top: 2rem;
+  }
+
+  .lg\:mr-xl {
+    margin-right: 2rem;
+  }
+
+  .lg\:mb-xl {
+    margin-bottom: 2rem;
+  }
+
+  .lg\:ml-xl {
+    margin-left: 2rem;
+  }
+
+  .lg\:mt-xxl {
+    margin-top: 2.5rem;
+  }
+
+  .lg\:mr-xxl {
+    margin-right: 2.5rem;
+  }
+
+  .lg\:mb-xxl {
+    margin-bottom: 2.5rem;
+  }
+
+  .lg\:ml-xxl {
+    margin-left: 2.5rem;
+  }
+
+  .lg\:mt-3xl {
+    margin-top: 3rem;
+  }
+
+  .lg\:mr-3xl {
+    margin-right: 3rem;
+  }
+
+  .lg\:mb-3xl {
+    margin-bottom: 3rem;
+  }
+
+  .lg\:ml-3xl {
+    margin-left: 3rem;
+  }
+
+  .lg\:mt-4xl {
+    margin-top: 4rem;
+  }
+
+  .lg\:mr-4xl {
+    margin-right: 4rem;
+  }
+
+  .lg\:mb-4xl {
+    margin-bottom: 4rem;
+  }
+
+  .lg\:ml-4xl {
+    margin-left: 4rem;
+  }
+
+  .lg\:mt-5xl {
+    margin-top: 8rem;
+  }
+
+  .lg\:mr-5xl {
+    margin-right: 8rem;
+  }
+
+  .lg\:mb-5xl {
+    margin-bottom: 8rem;
+  }
+
+  .lg\:ml-5xl {
+    margin-left: 8rem;
+  }
+
   .lg\:-mt-0 {
     margin-top: 0px;
   }
@@ -57103,6 +66244,182 @@ video {
     margin-left: -0.875rem;
   }
 
+  .lg\:-mt-3xs {
+    margin-top: -0.125rem;
+  }
+
+  .lg\:-mr-3xs {
+    margin-right: -0.125rem;
+  }
+
+  .lg\:-mb-3xs {
+    margin-bottom: -0.125rem;
+  }
+
+  .lg\:-ml-3xs {
+    margin-left: -0.125rem;
+  }
+
+  .lg\:-mt-xxs {
+    margin-top: -0.25rem;
+  }
+
+  .lg\:-mr-xxs {
+    margin-right: -0.25rem;
+  }
+
+  .lg\:-mb-xxs {
+    margin-bottom: -0.25rem;
+  }
+
+  .lg\:-ml-xxs {
+    margin-left: -0.25rem;
+  }
+
+  .lg\:-mt-xs {
+    margin-top: -0.5rem;
+  }
+
+  .lg\:-mr-xs {
+    margin-right: -0.5rem;
+  }
+
+  .lg\:-mb-xs {
+    margin-bottom: -0.5rem;
+  }
+
+  .lg\:-ml-xs {
+    margin-left: -0.5rem;
+  }
+
+  .lg\:-mt-s {
+    margin-top: -0.75rem;
+  }
+
+  .lg\:-mr-s {
+    margin-right: -0.75rem;
+  }
+
+  .lg\:-mb-s {
+    margin-bottom: -0.75rem;
+  }
+
+  .lg\:-ml-s {
+    margin-left: -0.75rem;
+  }
+
+  .lg\:-mt-m {
+    margin-top: -1rem;
+  }
+
+  .lg\:-mr-m {
+    margin-right: -1rem;
+  }
+
+  .lg\:-mb-m {
+    margin-bottom: -1rem;
+  }
+
+  .lg\:-ml-m {
+    margin-left: -1rem;
+  }
+
+  .lg\:-mt-l {
+    margin-top: -1.5rem;
+  }
+
+  .lg\:-mr-l {
+    margin-right: -1.5rem;
+  }
+
+  .lg\:-mb-l {
+    margin-bottom: -1.5rem;
+  }
+
+  .lg\:-ml-l {
+    margin-left: -1.5rem;
+  }
+
+  .lg\:-mt-xl {
+    margin-top: -2rem;
+  }
+
+  .lg\:-mr-xl {
+    margin-right: -2rem;
+  }
+
+  .lg\:-mb-xl {
+    margin-bottom: -2rem;
+  }
+
+  .lg\:-ml-xl {
+    margin-left: -2rem;
+  }
+
+  .lg\:-mt-xxl {
+    margin-top: -2.5rem;
+  }
+
+  .lg\:-mr-xxl {
+    margin-right: -2.5rem;
+  }
+
+  .lg\:-mb-xxl {
+    margin-bottom: -2.5rem;
+  }
+
+  .lg\:-ml-xxl {
+    margin-left: -2.5rem;
+  }
+
+  .lg\:-mt-3xl {
+    margin-top: -3rem;
+  }
+
+  .lg\:-mr-3xl {
+    margin-right: -3rem;
+  }
+
+  .lg\:-mb-3xl {
+    margin-bottom: -3rem;
+  }
+
+  .lg\:-ml-3xl {
+    margin-left: -3rem;
+  }
+
+  .lg\:-mt-4xl {
+    margin-top: -4rem;
+  }
+
+  .lg\:-mr-4xl {
+    margin-right: -4rem;
+  }
+
+  .lg\:-mb-4xl {
+    margin-bottom: -4rem;
+  }
+
+  .lg\:-ml-4xl {
+    margin-left: -4rem;
+  }
+
+  .lg\:-mt-5xl {
+    margin-top: -8rem;
+  }
+
+  .lg\:-mr-5xl {
+    margin-right: -8rem;
+  }
+
+  .lg\:-mb-5xl {
+    margin-bottom: -8rem;
+  }
+
+  .lg\:-ml-5xl {
+    margin-left: -8rem;
+  }
+
   .lg\:max-h-0 {
     max-height: 0px;
   }
@@ -57241,6 +66558,50 @@ video {
 
   .lg\:max-h-3\.5 {
     max-height: 0.875rem;
+  }
+
+  .lg\:max-h-3xs {
+    max-height: .125rem;
+  }
+
+  .lg\:max-h-xxs {
+    max-height: .25rem;
+  }
+
+  .lg\:max-h-xs {
+    max-height: .5rem;
+  }
+
+  .lg\:max-h-s {
+    max-height: .75rem;
+  }
+
+  .lg\:max-h-m {
+    max-height: 1rem;
+  }
+
+  .lg\:max-h-l {
+    max-height: 1.5rem;
+  }
+
+  .lg\:max-h-xl {
+    max-height: 2rem;
+  }
+
+  .lg\:max-h-xxl {
+    max-height: 2.5rem;
+  }
+
+  .lg\:max-h-3xl {
+    max-height: 3rem;
+  }
+
+  .lg\:max-h-4xl {
+    max-height: 4rem;
+  }
+
+  .lg\:max-h-5xl {
+    max-height: 8rem;
   }
 
   .lg\:max-h-full {
@@ -58017,6 +67378,50 @@ video {
     padding: 0.875rem;
   }
 
+  .lg\:p-3xs {
+    padding: .125rem;
+  }
+
+  .lg\:p-xxs {
+    padding: .25rem;
+  }
+
+  .lg\:p-xs {
+    padding: .5rem;
+  }
+
+  .lg\:p-s {
+    padding: .75rem;
+  }
+
+  .lg\:p-m {
+    padding: 1rem;
+  }
+
+  .lg\:p-l {
+    padding: 1.5rem;
+  }
+
+  .lg\:p-xl {
+    padding: 2rem;
+  }
+
+  .lg\:p-xxl {
+    padding: 2.5rem;
+  }
+
+  .lg\:p-3xl {
+    padding: 3rem;
+  }
+
+  .lg\:p-4xl {
+    padding: 4rem;
+  }
+
+  .lg\:p-5xl {
+    padding: 8rem;
+  }
+
   .lg\:py-0 {
     padding-top: 0px;
     padding-bottom: 0px;
@@ -58365,6 +67770,116 @@ video {
   .lg\:px-3\.5 {
     padding-left: 0.875rem;
     padding-right: 0.875rem;
+  }
+
+  .lg\:py-3xs {
+    padding-top: .125rem;
+    padding-bottom: .125rem;
+  }
+
+  .lg\:px-3xs {
+    padding-left: .125rem;
+    padding-right: .125rem;
+  }
+
+  .lg\:py-xxs {
+    padding-top: .25rem;
+    padding-bottom: .25rem;
+  }
+
+  .lg\:px-xxs {
+    padding-left: .25rem;
+    padding-right: .25rem;
+  }
+
+  .lg\:py-xs {
+    padding-top: .5rem;
+    padding-bottom: .5rem;
+  }
+
+  .lg\:px-xs {
+    padding-left: .5rem;
+    padding-right: .5rem;
+  }
+
+  .lg\:py-s {
+    padding-top: .75rem;
+    padding-bottom: .75rem;
+  }
+
+  .lg\:px-s {
+    padding-left: .75rem;
+    padding-right: .75rem;
+  }
+
+  .lg\:py-m {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .lg\:px-m {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .lg\:py-l {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .lg\:px-l {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .lg\:py-xl {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+
+  .lg\:px-xl {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
+  .lg\:py-xxl {
+    padding-top: 2.5rem;
+    padding-bottom: 2.5rem;
+  }
+
+  .lg\:px-xxl {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+  }
+
+  .lg\:py-3xl {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+
+  .lg\:px-3xl {
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
+
+  .lg\:py-4xl {
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+  }
+
+  .lg\:px-4xl {
+    padding-left: 4rem;
+    padding-right: 4rem;
+  }
+
+  .lg\:py-5xl {
+    padding-top: 8rem;
+    padding-bottom: 8rem;
+  }
+
+  .lg\:px-5xl {
+    padding-left: 8rem;
+    padding-right: 8rem;
   }
 
   .lg\:pt-0 {
@@ -58925,6 +68440,182 @@ video {
 
   .lg\:pl-3\.5 {
     padding-left: 0.875rem;
+  }
+
+  .lg\:pt-3xs {
+    padding-top: .125rem;
+  }
+
+  .lg\:pr-3xs {
+    padding-right: .125rem;
+  }
+
+  .lg\:pb-3xs {
+    padding-bottom: .125rem;
+  }
+
+  .lg\:pl-3xs {
+    padding-left: .125rem;
+  }
+
+  .lg\:pt-xxs {
+    padding-top: .25rem;
+  }
+
+  .lg\:pr-xxs {
+    padding-right: .25rem;
+  }
+
+  .lg\:pb-xxs {
+    padding-bottom: .25rem;
+  }
+
+  .lg\:pl-xxs {
+    padding-left: .25rem;
+  }
+
+  .lg\:pt-xs {
+    padding-top: .5rem;
+  }
+
+  .lg\:pr-xs {
+    padding-right: .5rem;
+  }
+
+  .lg\:pb-xs {
+    padding-bottom: .5rem;
+  }
+
+  .lg\:pl-xs {
+    padding-left: .5rem;
+  }
+
+  .lg\:pt-s {
+    padding-top: .75rem;
+  }
+
+  .lg\:pr-s {
+    padding-right: .75rem;
+  }
+
+  .lg\:pb-s {
+    padding-bottom: .75rem;
+  }
+
+  .lg\:pl-s {
+    padding-left: .75rem;
+  }
+
+  .lg\:pt-m {
+    padding-top: 1rem;
+  }
+
+  .lg\:pr-m {
+    padding-right: 1rem;
+  }
+
+  .lg\:pb-m {
+    padding-bottom: 1rem;
+  }
+
+  .lg\:pl-m {
+    padding-left: 1rem;
+  }
+
+  .lg\:pt-l {
+    padding-top: 1.5rem;
+  }
+
+  .lg\:pr-l {
+    padding-right: 1.5rem;
+  }
+
+  .lg\:pb-l {
+    padding-bottom: 1.5rem;
+  }
+
+  .lg\:pl-l {
+    padding-left: 1.5rem;
+  }
+
+  .lg\:pt-xl {
+    padding-top: 2rem;
+  }
+
+  .lg\:pr-xl {
+    padding-right: 2rem;
+  }
+
+  .lg\:pb-xl {
+    padding-bottom: 2rem;
+  }
+
+  .lg\:pl-xl {
+    padding-left: 2rem;
+  }
+
+  .lg\:pt-xxl {
+    padding-top: 2.5rem;
+  }
+
+  .lg\:pr-xxl {
+    padding-right: 2.5rem;
+  }
+
+  .lg\:pb-xxl {
+    padding-bottom: 2.5rem;
+  }
+
+  .lg\:pl-xxl {
+    padding-left: 2.5rem;
+  }
+
+  .lg\:pt-3xl {
+    padding-top: 3rem;
+  }
+
+  .lg\:pr-3xl {
+    padding-right: 3rem;
+  }
+
+  .lg\:pb-3xl {
+    padding-bottom: 3rem;
+  }
+
+  .lg\:pl-3xl {
+    padding-left: 3rem;
+  }
+
+  .lg\:pt-4xl {
+    padding-top: 4rem;
+  }
+
+  .lg\:pr-4xl {
+    padding-right: 4rem;
+  }
+
+  .lg\:pb-4xl {
+    padding-bottom: 4rem;
+  }
+
+  .lg\:pl-4xl {
+    padding-left: 4rem;
+  }
+
+  .lg\:pt-5xl {
+    padding-top: 8rem;
+  }
+
+  .lg\:pr-5xl {
+    padding-right: 8rem;
+  }
+
+  .lg\:pb-5xl {
+    padding-bottom: 8rem;
+  }
+
+  .lg\:pl-5xl {
+    padding-left: 8rem;
   }
 
   .lg\:placeholder-primary::-moz-placeholder {
@@ -59808,6 +69499,83 @@ video {
     left: 0.875rem;
   }
 
+  .lg\:inset-3xs {
+    top: .125rem;
+    right: .125rem;
+    bottom: .125rem;
+    left: .125rem;
+  }
+
+  .lg\:inset-xxs {
+    top: .25rem;
+    right: .25rem;
+    bottom: .25rem;
+    left: .25rem;
+  }
+
+  .lg\:inset-xs {
+    top: .5rem;
+    right: .5rem;
+    bottom: .5rem;
+    left: .5rem;
+  }
+
+  .lg\:inset-s {
+    top: .75rem;
+    right: .75rem;
+    bottom: .75rem;
+    left: .75rem;
+  }
+
+  .lg\:inset-m {
+    top: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    left: 1rem;
+  }
+
+  .lg\:inset-l {
+    top: 1.5rem;
+    right: 1.5rem;
+    bottom: 1.5rem;
+    left: 1.5rem;
+  }
+
+  .lg\:inset-xl {
+    top: 2rem;
+    right: 2rem;
+    bottom: 2rem;
+    left: 2rem;
+  }
+
+  .lg\:inset-xxl {
+    top: 2.5rem;
+    right: 2.5rem;
+    bottom: 2.5rem;
+    left: 2.5rem;
+  }
+
+  .lg\:inset-3xl {
+    top: 3rem;
+    right: 3rem;
+    bottom: 3rem;
+    left: 3rem;
+  }
+
+  .lg\:inset-4xl {
+    top: 4rem;
+    right: 4rem;
+    bottom: 4rem;
+    left: 4rem;
+  }
+
+  .lg\:inset-5xl {
+    top: 8rem;
+    right: 8rem;
+    bottom: 8rem;
+    left: 8rem;
+  }
+
   .lg\:-inset-0 {
     top: 0px;
     right: 0px;
@@ -60051,6 +69819,83 @@ video {
     right: -0.875rem;
     bottom: -0.875rem;
     left: -0.875rem;
+  }
+
+  .lg\:-inset-3xs {
+    top: -0.125rem;
+    right: -0.125rem;
+    bottom: -0.125rem;
+    left: -0.125rem;
+  }
+
+  .lg\:-inset-xxs {
+    top: -0.25rem;
+    right: -0.25rem;
+    bottom: -0.25rem;
+    left: -0.25rem;
+  }
+
+  .lg\:-inset-xs {
+    top: -0.5rem;
+    right: -0.5rem;
+    bottom: -0.5rem;
+    left: -0.5rem;
+  }
+
+  .lg\:-inset-s {
+    top: -0.75rem;
+    right: -0.75rem;
+    bottom: -0.75rem;
+    left: -0.75rem;
+  }
+
+  .lg\:-inset-m {
+    top: -1rem;
+    right: -1rem;
+    bottom: -1rem;
+    left: -1rem;
+  }
+
+  .lg\:-inset-l {
+    top: -1.5rem;
+    right: -1.5rem;
+    bottom: -1.5rem;
+    left: -1.5rem;
+  }
+
+  .lg\:-inset-xl {
+    top: -2rem;
+    right: -2rem;
+    bottom: -2rem;
+    left: -2rem;
+  }
+
+  .lg\:-inset-xxl {
+    top: -2.5rem;
+    right: -2.5rem;
+    bottom: -2.5rem;
+    left: -2.5rem;
+  }
+
+  .lg\:-inset-3xl {
+    top: -3rem;
+    right: -3rem;
+    bottom: -3rem;
+    left: -3rem;
+  }
+
+  .lg\:-inset-4xl {
+    top: -4rem;
+    right: -4rem;
+    bottom: -4rem;
+    left: -4rem;
+  }
+
+  .lg\:-inset-5xl {
+    top: -8rem;
+    right: -8rem;
+    bottom: -8rem;
+    left: -8rem;
   }
 
   .lg\:inset-1\/2 {
@@ -60511,6 +70356,116 @@ video {
     left: 0.875rem;
   }
 
+  .lg\:inset-y-3xs {
+    top: .125rem;
+    bottom: .125rem;
+  }
+
+  .lg\:inset-x-3xs {
+    right: .125rem;
+    left: .125rem;
+  }
+
+  .lg\:inset-y-xxs {
+    top: .25rem;
+    bottom: .25rem;
+  }
+
+  .lg\:inset-x-xxs {
+    right: .25rem;
+    left: .25rem;
+  }
+
+  .lg\:inset-y-xs {
+    top: .5rem;
+    bottom: .5rem;
+  }
+
+  .lg\:inset-x-xs {
+    right: .5rem;
+    left: .5rem;
+  }
+
+  .lg\:inset-y-s {
+    top: .75rem;
+    bottom: .75rem;
+  }
+
+  .lg\:inset-x-s {
+    right: .75rem;
+    left: .75rem;
+  }
+
+  .lg\:inset-y-m {
+    top: 1rem;
+    bottom: 1rem;
+  }
+
+  .lg\:inset-x-m {
+    right: 1rem;
+    left: 1rem;
+  }
+
+  .lg\:inset-y-l {
+    top: 1.5rem;
+    bottom: 1.5rem;
+  }
+
+  .lg\:inset-x-l {
+    right: 1.5rem;
+    left: 1.5rem;
+  }
+
+  .lg\:inset-y-xl {
+    top: 2rem;
+    bottom: 2rem;
+  }
+
+  .lg\:inset-x-xl {
+    right: 2rem;
+    left: 2rem;
+  }
+
+  .lg\:inset-y-xxl {
+    top: 2.5rem;
+    bottom: 2.5rem;
+  }
+
+  .lg\:inset-x-xxl {
+    right: 2.5rem;
+    left: 2.5rem;
+  }
+
+  .lg\:inset-y-3xl {
+    top: 3rem;
+    bottom: 3rem;
+  }
+
+  .lg\:inset-x-3xl {
+    right: 3rem;
+    left: 3rem;
+  }
+
+  .lg\:inset-y-4xl {
+    top: 4rem;
+    bottom: 4rem;
+  }
+
+  .lg\:inset-x-4xl {
+    right: 4rem;
+    left: 4rem;
+  }
+
+  .lg\:inset-y-5xl {
+    top: 8rem;
+    bottom: 8rem;
+  }
+
+  .lg\:inset-x-5xl {
+    right: 8rem;
+    left: 8rem;
+  }
+
   .lg\:-inset-y-0 {
     top: 0px;
     bottom: 0px;
@@ -60859,6 +70814,116 @@ video {
   .lg\:-inset-x-3\.5 {
     right: -0.875rem;
     left: -0.875rem;
+  }
+
+  .lg\:-inset-y-3xs {
+    top: -0.125rem;
+    bottom: -0.125rem;
+  }
+
+  .lg\:-inset-x-3xs {
+    right: -0.125rem;
+    left: -0.125rem;
+  }
+
+  .lg\:-inset-y-xxs {
+    top: -0.25rem;
+    bottom: -0.25rem;
+  }
+
+  .lg\:-inset-x-xxs {
+    right: -0.25rem;
+    left: -0.25rem;
+  }
+
+  .lg\:-inset-y-xs {
+    top: -0.5rem;
+    bottom: -0.5rem;
+  }
+
+  .lg\:-inset-x-xs {
+    right: -0.5rem;
+    left: -0.5rem;
+  }
+
+  .lg\:-inset-y-s {
+    top: -0.75rem;
+    bottom: -0.75rem;
+  }
+
+  .lg\:-inset-x-s {
+    right: -0.75rem;
+    left: -0.75rem;
+  }
+
+  .lg\:-inset-y-m {
+    top: -1rem;
+    bottom: -1rem;
+  }
+
+  .lg\:-inset-x-m {
+    right: -1rem;
+    left: -1rem;
+  }
+
+  .lg\:-inset-y-l {
+    top: -1.5rem;
+    bottom: -1.5rem;
+  }
+
+  .lg\:-inset-x-l {
+    right: -1.5rem;
+    left: -1.5rem;
+  }
+
+  .lg\:-inset-y-xl {
+    top: -2rem;
+    bottom: -2rem;
+  }
+
+  .lg\:-inset-x-xl {
+    right: -2rem;
+    left: -2rem;
+  }
+
+  .lg\:-inset-y-xxl {
+    top: -2.5rem;
+    bottom: -2.5rem;
+  }
+
+  .lg\:-inset-x-xxl {
+    right: -2.5rem;
+    left: -2.5rem;
+  }
+
+  .lg\:-inset-y-3xl {
+    top: -3rem;
+    bottom: -3rem;
+  }
+
+  .lg\:-inset-x-3xl {
+    right: -3rem;
+    left: -3rem;
+  }
+
+  .lg\:-inset-y-4xl {
+    top: -4rem;
+    bottom: -4rem;
+  }
+
+  .lg\:-inset-x-4xl {
+    right: -4rem;
+    left: -4rem;
+  }
+
+  .lg\:-inset-y-5xl {
+    top: -8rem;
+    bottom: -8rem;
+  }
+
+  .lg\:-inset-x-5xl {
+    right: -8rem;
+    left: -8rem;
   }
 
   .lg\:inset-y-1\/2 {
@@ -61577,6 +71642,182 @@ video {
     left: 0.875rem;
   }
 
+  .lg\:top-3xs {
+    top: .125rem;
+  }
+
+  .lg\:right-3xs {
+    right: .125rem;
+  }
+
+  .lg\:bottom-3xs {
+    bottom: .125rem;
+  }
+
+  .lg\:left-3xs {
+    left: .125rem;
+  }
+
+  .lg\:top-xxs {
+    top: .25rem;
+  }
+
+  .lg\:right-xxs {
+    right: .25rem;
+  }
+
+  .lg\:bottom-xxs {
+    bottom: .25rem;
+  }
+
+  .lg\:left-xxs {
+    left: .25rem;
+  }
+
+  .lg\:top-xs {
+    top: .5rem;
+  }
+
+  .lg\:right-xs {
+    right: .5rem;
+  }
+
+  .lg\:bottom-xs {
+    bottom: .5rem;
+  }
+
+  .lg\:left-xs {
+    left: .5rem;
+  }
+
+  .lg\:top-s {
+    top: .75rem;
+  }
+
+  .lg\:right-s {
+    right: .75rem;
+  }
+
+  .lg\:bottom-s {
+    bottom: .75rem;
+  }
+
+  .lg\:left-s {
+    left: .75rem;
+  }
+
+  .lg\:top-m {
+    top: 1rem;
+  }
+
+  .lg\:right-m {
+    right: 1rem;
+  }
+
+  .lg\:bottom-m {
+    bottom: 1rem;
+  }
+
+  .lg\:left-m {
+    left: 1rem;
+  }
+
+  .lg\:top-l {
+    top: 1.5rem;
+  }
+
+  .lg\:right-l {
+    right: 1.5rem;
+  }
+
+  .lg\:bottom-l {
+    bottom: 1.5rem;
+  }
+
+  .lg\:left-l {
+    left: 1.5rem;
+  }
+
+  .lg\:top-xl {
+    top: 2rem;
+  }
+
+  .lg\:right-xl {
+    right: 2rem;
+  }
+
+  .lg\:bottom-xl {
+    bottom: 2rem;
+  }
+
+  .lg\:left-xl {
+    left: 2rem;
+  }
+
+  .lg\:top-xxl {
+    top: 2.5rem;
+  }
+
+  .lg\:right-xxl {
+    right: 2.5rem;
+  }
+
+  .lg\:bottom-xxl {
+    bottom: 2.5rem;
+  }
+
+  .lg\:left-xxl {
+    left: 2.5rem;
+  }
+
+  .lg\:top-3xl {
+    top: 3rem;
+  }
+
+  .lg\:right-3xl {
+    right: 3rem;
+  }
+
+  .lg\:bottom-3xl {
+    bottom: 3rem;
+  }
+
+  .lg\:left-3xl {
+    left: 3rem;
+  }
+
+  .lg\:top-4xl {
+    top: 4rem;
+  }
+
+  .lg\:right-4xl {
+    right: 4rem;
+  }
+
+  .lg\:bottom-4xl {
+    bottom: 4rem;
+  }
+
+  .lg\:left-4xl {
+    left: 4rem;
+  }
+
+  .lg\:top-5xl {
+    top: 8rem;
+  }
+
+  .lg\:right-5xl {
+    right: 8rem;
+  }
+
+  .lg\:bottom-5xl {
+    bottom: 8rem;
+  }
+
+  .lg\:left-5xl {
+    left: 8rem;
+  }
+
   .lg\:-top-0 {
     top: 0px;
   }
@@ -62135,6 +72376,182 @@ video {
 
   .lg\:-left-3\.5 {
     left: -0.875rem;
+  }
+
+  .lg\:-top-3xs {
+    top: -0.125rem;
+  }
+
+  .lg\:-right-3xs {
+    right: -0.125rem;
+  }
+
+  .lg\:-bottom-3xs {
+    bottom: -0.125rem;
+  }
+
+  .lg\:-left-3xs {
+    left: -0.125rem;
+  }
+
+  .lg\:-top-xxs {
+    top: -0.25rem;
+  }
+
+  .lg\:-right-xxs {
+    right: -0.25rem;
+  }
+
+  .lg\:-bottom-xxs {
+    bottom: -0.25rem;
+  }
+
+  .lg\:-left-xxs {
+    left: -0.25rem;
+  }
+
+  .lg\:-top-xs {
+    top: -0.5rem;
+  }
+
+  .lg\:-right-xs {
+    right: -0.5rem;
+  }
+
+  .lg\:-bottom-xs {
+    bottom: -0.5rem;
+  }
+
+  .lg\:-left-xs {
+    left: -0.5rem;
+  }
+
+  .lg\:-top-s {
+    top: -0.75rem;
+  }
+
+  .lg\:-right-s {
+    right: -0.75rem;
+  }
+
+  .lg\:-bottom-s {
+    bottom: -0.75rem;
+  }
+
+  .lg\:-left-s {
+    left: -0.75rem;
+  }
+
+  .lg\:-top-m {
+    top: -1rem;
+  }
+
+  .lg\:-right-m {
+    right: -1rem;
+  }
+
+  .lg\:-bottom-m {
+    bottom: -1rem;
+  }
+
+  .lg\:-left-m {
+    left: -1rem;
+  }
+
+  .lg\:-top-l {
+    top: -1.5rem;
+  }
+
+  .lg\:-right-l {
+    right: -1.5rem;
+  }
+
+  .lg\:-bottom-l {
+    bottom: -1.5rem;
+  }
+
+  .lg\:-left-l {
+    left: -1.5rem;
+  }
+
+  .lg\:-top-xl {
+    top: -2rem;
+  }
+
+  .lg\:-right-xl {
+    right: -2rem;
+  }
+
+  .lg\:-bottom-xl {
+    bottom: -2rem;
+  }
+
+  .lg\:-left-xl {
+    left: -2rem;
+  }
+
+  .lg\:-top-xxl {
+    top: -2.5rem;
+  }
+
+  .lg\:-right-xxl {
+    right: -2.5rem;
+  }
+
+  .lg\:-bottom-xxl {
+    bottom: -2.5rem;
+  }
+
+  .lg\:-left-xxl {
+    left: -2.5rem;
+  }
+
+  .lg\:-top-3xl {
+    top: -3rem;
+  }
+
+  .lg\:-right-3xl {
+    right: -3rem;
+  }
+
+  .lg\:-bottom-3xl {
+    bottom: -3rem;
+  }
+
+  .lg\:-left-3xl {
+    left: -3rem;
+  }
+
+  .lg\:-top-4xl {
+    top: -4rem;
+  }
+
+  .lg\:-right-4xl {
+    right: -4rem;
+  }
+
+  .lg\:-bottom-4xl {
+    bottom: -4rem;
+  }
+
+  .lg\:-left-4xl {
+    left: -4rem;
+  }
+
+  .lg\:-top-5xl {
+    top: -8rem;
+  }
+
+  .lg\:-right-5xl {
+    right: -8rem;
+  }
+
+  .lg\:-bottom-5xl {
+    bottom: -8rem;
+  }
+
+  .lg\:-left-5xl {
+    left: -8rem;
   }
 
   .lg\:top-1\/2 {
@@ -64010,6 +74427,50 @@ video {
     width: 0.875rem;
   }
 
+  .lg\:w-3xs {
+    width: .125rem;
+  }
+
+  .lg\:w-xxs {
+    width: .25rem;
+  }
+
+  .lg\:w-xs {
+    width: .5rem;
+  }
+
+  .lg\:w-s {
+    width: .75rem;
+  }
+
+  .lg\:w-m {
+    width: 1rem;
+  }
+
+  .lg\:w-l {
+    width: 1.5rem;
+  }
+
+  .lg\:w-xl {
+    width: 2rem;
+  }
+
+  .lg\:w-xxl {
+    width: 2.5rem;
+  }
+
+  .lg\:w-3xl {
+    width: 3rem;
+  }
+
+  .lg\:w-4xl {
+    width: 4rem;
+  }
+
+  .lg\:w-5xl {
+    width: 8rem;
+  }
+
   .lg\:w-1\/2 {
     width: 50%;
   }
@@ -64358,6 +74819,50 @@ video {
     gap: 0.875rem;
   }
 
+  .lg\:gap-3xs {
+    gap: .125rem;
+  }
+
+  .lg\:gap-xxs {
+    gap: .25rem;
+  }
+
+  .lg\:gap-xs {
+    gap: .5rem;
+  }
+
+  .lg\:gap-s {
+    gap: .75rem;
+  }
+
+  .lg\:gap-m {
+    gap: 1rem;
+  }
+
+  .lg\:gap-l {
+    gap: 1.5rem;
+  }
+
+  .lg\:gap-xl {
+    gap: 2rem;
+  }
+
+  .lg\:gap-xxl {
+    gap: 2.5rem;
+  }
+
+  .lg\:gap-3xl {
+    gap: 3rem;
+  }
+
+  .lg\:gap-4xl {
+    gap: 4rem;
+  }
+
+  .lg\:gap-5xl {
+    gap: 8rem;
+  }
+
   .lg\:gap-x-0 {
     -moz-column-gap: 0px;
          column-gap: 0px;
@@ -64533,6 +75038,61 @@ video {
          column-gap: 0.875rem;
   }
 
+  .lg\:gap-x-3xs {
+    -moz-column-gap: .125rem;
+         column-gap: .125rem;
+  }
+
+  .lg\:gap-x-xxs {
+    -moz-column-gap: .25rem;
+         column-gap: .25rem;
+  }
+
+  .lg\:gap-x-xs {
+    -moz-column-gap: .5rem;
+         column-gap: .5rem;
+  }
+
+  .lg\:gap-x-s {
+    -moz-column-gap: .75rem;
+         column-gap: .75rem;
+  }
+
+  .lg\:gap-x-m {
+    -moz-column-gap: 1rem;
+         column-gap: 1rem;
+  }
+
+  .lg\:gap-x-l {
+    -moz-column-gap: 1.5rem;
+         column-gap: 1.5rem;
+  }
+
+  .lg\:gap-x-xl {
+    -moz-column-gap: 2rem;
+         column-gap: 2rem;
+  }
+
+  .lg\:gap-x-xxl {
+    -moz-column-gap: 2.5rem;
+         column-gap: 2.5rem;
+  }
+
+  .lg\:gap-x-3xl {
+    -moz-column-gap: 3rem;
+         column-gap: 3rem;
+  }
+
+  .lg\:gap-x-4xl {
+    -moz-column-gap: 4rem;
+         column-gap: 4rem;
+  }
+
+  .lg\:gap-x-5xl {
+    -moz-column-gap: 8rem;
+         column-gap: 8rem;
+  }
+
   .lg\:gap-y-0 {
     row-gap: 0px;
   }
@@ -64671,6 +75231,50 @@ video {
 
   .lg\:gap-y-3\.5 {
     row-gap: 0.875rem;
+  }
+
+  .lg\:gap-y-3xs {
+    row-gap: .125rem;
+  }
+
+  .lg\:gap-y-xxs {
+    row-gap: .25rem;
+  }
+
+  .lg\:gap-y-xs {
+    row-gap: .5rem;
+  }
+
+  .lg\:gap-y-s {
+    row-gap: .75rem;
+  }
+
+  .lg\:gap-y-m {
+    row-gap: 1rem;
+  }
+
+  .lg\:gap-y-l {
+    row-gap: 1.5rem;
+  }
+
+  .lg\:gap-y-xl {
+    row-gap: 2rem;
+  }
+
+  .lg\:gap-y-xxl {
+    row-gap: 2.5rem;
+  }
+
+  .lg\:gap-y-3xl {
+    row-gap: 3rem;
+  }
+
+  .lg\:gap-y-4xl {
+    row-gap: 4rem;
+  }
+
+  .lg\:gap-y-5xl {
+    row-gap: 8rem;
   }
 
   .lg\:grid-flow-row {
@@ -65865,6 +76469,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .lg\:translate-x-3xs {
+    --tw-translate-x: .125rem;
+  }
+
+  .lg\:translate-x-xxs {
+    --tw-translate-x: .25rem;
+  }
+
+  .lg\:translate-x-xs {
+    --tw-translate-x: .5rem;
+  }
+
+  .lg\:translate-x-s {
+    --tw-translate-x: .75rem;
+  }
+
+  .lg\:translate-x-m {
+    --tw-translate-x: 1rem;
+  }
+
+  .lg\:translate-x-l {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .lg\:translate-x-xl {
+    --tw-translate-x: 2rem;
+  }
+
+  .lg\:translate-x-xxl {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .lg\:translate-x-3xl {
+    --tw-translate-x: 3rem;
+  }
+
+  .lg\:translate-x-4xl {
+    --tw-translate-x: 4rem;
+  }
+
+  .lg\:translate-x-5xl {
+    --tw-translate-x: 8rem;
+  }
+
   .lg\:-translate-x-0 {
     --tw-translate-x: 0px;
   }
@@ -66003,6 +76651,50 @@ video {
 
   .lg\:-translate-x-3\.5 {
     --tw-translate-x: -0.875rem;
+  }
+
+  .lg\:-translate-x-3xs {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .lg\:-translate-x-xxs {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .lg\:-translate-x-xs {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .lg\:-translate-x-s {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .lg\:-translate-x-m {
+    --tw-translate-x: -1rem;
+  }
+
+  .lg\:-translate-x-l {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .lg\:-translate-x-xl {
+    --tw-translate-x: -2rem;
+  }
+
+  .lg\:-translate-x-xxl {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .lg\:-translate-x-3xl {
+    --tw-translate-x: -3rem;
+  }
+
+  .lg\:-translate-x-4xl {
+    --tw-translate-x: -4rem;
+  }
+
+  .lg\:-translate-x-5xl {
+    --tw-translate-x: -8rem;
   }
 
   .lg\:translate-x-1\/2 {
@@ -66201,6 +76893,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .lg\:translate-y-3xs {
+    --tw-translate-y: .125rem;
+  }
+
+  .lg\:translate-y-xxs {
+    --tw-translate-y: .25rem;
+  }
+
+  .lg\:translate-y-xs {
+    --tw-translate-y: .5rem;
+  }
+
+  .lg\:translate-y-s {
+    --tw-translate-y: .75rem;
+  }
+
+  .lg\:translate-y-m {
+    --tw-translate-y: 1rem;
+  }
+
+  .lg\:translate-y-l {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .lg\:translate-y-xl {
+    --tw-translate-y: 2rem;
+  }
+
+  .lg\:translate-y-xxl {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .lg\:translate-y-3xl {
+    --tw-translate-y: 3rem;
+  }
+
+  .lg\:translate-y-4xl {
+    --tw-translate-y: 4rem;
+  }
+
+  .lg\:translate-y-5xl {
+    --tw-translate-y: 8rem;
+  }
+
   .lg\:-translate-y-0 {
     --tw-translate-y: 0px;
   }
@@ -66339,6 +77075,50 @@ video {
 
   .lg\:-translate-y-3\.5 {
     --tw-translate-y: -0.875rem;
+  }
+
+  .lg\:-translate-y-3xs {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .lg\:-translate-y-xxs {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .lg\:-translate-y-xs {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .lg\:-translate-y-s {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .lg\:-translate-y-m {
+    --tw-translate-y: -1rem;
+  }
+
+  .lg\:-translate-y-l {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .lg\:-translate-y-xl {
+    --tw-translate-y: -2rem;
+  }
+
+  .lg\:-translate-y-xxl {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .lg\:-translate-y-3xl {
+    --tw-translate-y: -3rem;
+  }
+
+  .lg\:-translate-y-4xl {
+    --tw-translate-y: -4rem;
+  }
+
+  .lg\:-translate-y-5xl {
+    --tw-translate-y: -8rem;
   }
 
   .lg\:translate-y-1\/2 {
@@ -66537,6 +77317,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .lg\:hover\:translate-x-3xs:hover {
+    --tw-translate-x: .125rem;
+  }
+
+  .lg\:hover\:translate-x-xxs:hover {
+    --tw-translate-x: .25rem;
+  }
+
+  .lg\:hover\:translate-x-xs:hover {
+    --tw-translate-x: .5rem;
+  }
+
+  .lg\:hover\:translate-x-s:hover {
+    --tw-translate-x: .75rem;
+  }
+
+  .lg\:hover\:translate-x-m:hover {
+    --tw-translate-x: 1rem;
+  }
+
+  .lg\:hover\:translate-x-l:hover {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .lg\:hover\:translate-x-xl:hover {
+    --tw-translate-x: 2rem;
+  }
+
+  .lg\:hover\:translate-x-xxl:hover {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .lg\:hover\:translate-x-3xl:hover {
+    --tw-translate-x: 3rem;
+  }
+
+  .lg\:hover\:translate-x-4xl:hover {
+    --tw-translate-x: 4rem;
+  }
+
+  .lg\:hover\:translate-x-5xl:hover {
+    --tw-translate-x: 8rem;
+  }
+
   .lg\:hover\:-translate-x-0:hover {
     --tw-translate-x: 0px;
   }
@@ -66675,6 +77499,50 @@ video {
 
   .lg\:hover\:-translate-x-3\.5:hover {
     --tw-translate-x: -0.875rem;
+  }
+
+  .lg\:hover\:-translate-x-3xs:hover {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .lg\:hover\:-translate-x-xxs:hover {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .lg\:hover\:-translate-x-xs:hover {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .lg\:hover\:-translate-x-s:hover {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .lg\:hover\:-translate-x-m:hover {
+    --tw-translate-x: -1rem;
+  }
+
+  .lg\:hover\:-translate-x-l:hover {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .lg\:hover\:-translate-x-xl:hover {
+    --tw-translate-x: -2rem;
+  }
+
+  .lg\:hover\:-translate-x-xxl:hover {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .lg\:hover\:-translate-x-3xl:hover {
+    --tw-translate-x: -3rem;
+  }
+
+  .lg\:hover\:-translate-x-4xl:hover {
+    --tw-translate-x: -4rem;
+  }
+
+  .lg\:hover\:-translate-x-5xl:hover {
+    --tw-translate-x: -8rem;
   }
 
   .lg\:hover\:translate-x-1\/2:hover {
@@ -66873,6 +77741,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .lg\:hover\:translate-y-3xs:hover {
+    --tw-translate-y: .125rem;
+  }
+
+  .lg\:hover\:translate-y-xxs:hover {
+    --tw-translate-y: .25rem;
+  }
+
+  .lg\:hover\:translate-y-xs:hover {
+    --tw-translate-y: .5rem;
+  }
+
+  .lg\:hover\:translate-y-s:hover {
+    --tw-translate-y: .75rem;
+  }
+
+  .lg\:hover\:translate-y-m:hover {
+    --tw-translate-y: 1rem;
+  }
+
+  .lg\:hover\:translate-y-l:hover {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .lg\:hover\:translate-y-xl:hover {
+    --tw-translate-y: 2rem;
+  }
+
+  .lg\:hover\:translate-y-xxl:hover {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .lg\:hover\:translate-y-3xl:hover {
+    --tw-translate-y: 3rem;
+  }
+
+  .lg\:hover\:translate-y-4xl:hover {
+    --tw-translate-y: 4rem;
+  }
+
+  .lg\:hover\:translate-y-5xl:hover {
+    --tw-translate-y: 8rem;
+  }
+
   .lg\:hover\:-translate-y-0:hover {
     --tw-translate-y: 0px;
   }
@@ -67011,6 +77923,50 @@ video {
 
   .lg\:hover\:-translate-y-3\.5:hover {
     --tw-translate-y: -0.875rem;
+  }
+
+  .lg\:hover\:-translate-y-3xs:hover {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .lg\:hover\:-translate-y-xxs:hover {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .lg\:hover\:-translate-y-xs:hover {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .lg\:hover\:-translate-y-s:hover {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .lg\:hover\:-translate-y-m:hover {
+    --tw-translate-y: -1rem;
+  }
+
+  .lg\:hover\:-translate-y-l:hover {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .lg\:hover\:-translate-y-xl:hover {
+    --tw-translate-y: -2rem;
+  }
+
+  .lg\:hover\:-translate-y-xxl:hover {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .lg\:hover\:-translate-y-3xl:hover {
+    --tw-translate-y: -3rem;
+  }
+
+  .lg\:hover\:-translate-y-4xl:hover {
+    --tw-translate-y: -4rem;
+  }
+
+  .lg\:hover\:-translate-y-5xl:hover {
+    --tw-translate-y: -8rem;
   }
 
   .lg\:hover\:translate-y-1\/2:hover {
@@ -67209,6 +78165,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .lg\:focus\:translate-x-3xs:focus {
+    --tw-translate-x: .125rem;
+  }
+
+  .lg\:focus\:translate-x-xxs:focus {
+    --tw-translate-x: .25rem;
+  }
+
+  .lg\:focus\:translate-x-xs:focus {
+    --tw-translate-x: .5rem;
+  }
+
+  .lg\:focus\:translate-x-s:focus {
+    --tw-translate-x: .75rem;
+  }
+
+  .lg\:focus\:translate-x-m:focus {
+    --tw-translate-x: 1rem;
+  }
+
+  .lg\:focus\:translate-x-l:focus {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .lg\:focus\:translate-x-xl:focus {
+    --tw-translate-x: 2rem;
+  }
+
+  .lg\:focus\:translate-x-xxl:focus {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .lg\:focus\:translate-x-3xl:focus {
+    --tw-translate-x: 3rem;
+  }
+
+  .lg\:focus\:translate-x-4xl:focus {
+    --tw-translate-x: 4rem;
+  }
+
+  .lg\:focus\:translate-x-5xl:focus {
+    --tw-translate-x: 8rem;
+  }
+
   .lg\:focus\:-translate-x-0:focus {
     --tw-translate-x: 0px;
   }
@@ -67347,6 +78347,50 @@ video {
 
   .lg\:focus\:-translate-x-3\.5:focus {
     --tw-translate-x: -0.875rem;
+  }
+
+  .lg\:focus\:-translate-x-3xs:focus {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .lg\:focus\:-translate-x-xxs:focus {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .lg\:focus\:-translate-x-xs:focus {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .lg\:focus\:-translate-x-s:focus {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .lg\:focus\:-translate-x-m:focus {
+    --tw-translate-x: -1rem;
+  }
+
+  .lg\:focus\:-translate-x-l:focus {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .lg\:focus\:-translate-x-xl:focus {
+    --tw-translate-x: -2rem;
+  }
+
+  .lg\:focus\:-translate-x-xxl:focus {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .lg\:focus\:-translate-x-3xl:focus {
+    --tw-translate-x: -3rem;
+  }
+
+  .lg\:focus\:-translate-x-4xl:focus {
+    --tw-translate-x: -4rem;
+  }
+
+  .lg\:focus\:-translate-x-5xl:focus {
+    --tw-translate-x: -8rem;
   }
 
   .lg\:focus\:translate-x-1\/2:focus {
@@ -67545,6 +78589,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .lg\:focus\:translate-y-3xs:focus {
+    --tw-translate-y: .125rem;
+  }
+
+  .lg\:focus\:translate-y-xxs:focus {
+    --tw-translate-y: .25rem;
+  }
+
+  .lg\:focus\:translate-y-xs:focus {
+    --tw-translate-y: .5rem;
+  }
+
+  .lg\:focus\:translate-y-s:focus {
+    --tw-translate-y: .75rem;
+  }
+
+  .lg\:focus\:translate-y-m:focus {
+    --tw-translate-y: 1rem;
+  }
+
+  .lg\:focus\:translate-y-l:focus {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .lg\:focus\:translate-y-xl:focus {
+    --tw-translate-y: 2rem;
+  }
+
+  .lg\:focus\:translate-y-xxl:focus {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .lg\:focus\:translate-y-3xl:focus {
+    --tw-translate-y: 3rem;
+  }
+
+  .lg\:focus\:translate-y-4xl:focus {
+    --tw-translate-y: 4rem;
+  }
+
+  .lg\:focus\:translate-y-5xl:focus {
+    --tw-translate-y: 8rem;
+  }
+
   .lg\:focus\:-translate-y-0:focus {
     --tw-translate-y: 0px;
   }
@@ -67683,6 +78771,50 @@ video {
 
   .lg\:focus\:-translate-y-3\.5:focus {
     --tw-translate-y: -0.875rem;
+  }
+
+  .lg\:focus\:-translate-y-3xs:focus {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .lg\:focus\:-translate-y-xxs:focus {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .lg\:focus\:-translate-y-xs:focus {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .lg\:focus\:-translate-y-s:focus {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .lg\:focus\:-translate-y-m:focus {
+    --tw-translate-y: -1rem;
+  }
+
+  .lg\:focus\:-translate-y-l:focus {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .lg\:focus\:-translate-y-xl:focus {
+    --tw-translate-y: -2rem;
+  }
+
+  .lg\:focus\:-translate-y-xxl:focus {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .lg\:focus\:-translate-y-3xl:focus {
+    --tw-translate-y: -3rem;
+  }
+
+  .lg\:focus\:-translate-y-4xl:focus {
+    --tw-translate-y: -4rem;
+  }
+
+  .lg\:focus\:-translate-y-5xl:focus {
+    --tw-translate-y: -8rem;
   }
 
   .lg\:focus\:translate-y-1\/2:focus {
@@ -68606,6 +79738,138 @@ video {
     margin-left: calc(0.875rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
+  .xl\:space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.125rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.125rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.125rem * var(--tw-space-x-reverse));
+    margin-left: calc(.125rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.25rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.25rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:space-y-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.5rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:space-y-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.75rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.75rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:space-y-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1rem * var(--tw-space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:space-y-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:space-y-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2rem * var(--tw-space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(2.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(2.5rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(3rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(3rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(3rem * var(--tw-space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(4rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(4rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(4rem * var(--tw-space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(8rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(8rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(8rem * var(--tw-space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
   .xl\:-space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
@@ -69024,6 +80288,138 @@ video {
     --tw-space-x-reverse: 0;
     margin-right: calc(-0.875rem * var(--tw-space-x-reverse));
     margin-left: calc(-0.875rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.125rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.125rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.125rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.25rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.25rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.5rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.75rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.75rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-1rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-1rem * var(--tw-space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-1.5rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-2rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-2rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-2rem * var(--tw-space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-2.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-2.5rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-3rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-3rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-3rem * var(--tw-space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-4rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-4rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-4rem * var(--tw-space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .xl\:-space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-8rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-8rem * var(--tw-space-y-reverse));
+  }
+
+  .xl\:-space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-8rem * var(--tw-space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -71682,6 +83078,50 @@ video {
     height: 0.875rem;
   }
 
+  .xl\:h-3xs {
+    height: .125rem;
+  }
+
+  .xl\:h-xxs {
+    height: .25rem;
+  }
+
+  .xl\:h-xs {
+    height: .5rem;
+  }
+
+  .xl\:h-s {
+    height: .75rem;
+  }
+
+  .xl\:h-m {
+    height: 1rem;
+  }
+
+  .xl\:h-l {
+    height: 1.5rem;
+  }
+
+  .xl\:h-xl {
+    height: 2rem;
+  }
+
+  .xl\:h-xxl {
+    height: 2.5rem;
+  }
+
+  .xl\:h-3xl {
+    height: 3rem;
+  }
+
+  .xl\:h-4xl {
+    height: 4rem;
+  }
+
+  .xl\:h-5xl {
+    height: 8rem;
+  }
+
   .xl\:h-1\/2 {
     height: 50%;
   }
@@ -71998,6 +83438,50 @@ video {
     margin: 0.875rem;
   }
 
+  .xl\:m-3xs {
+    margin: .125rem;
+  }
+
+  .xl\:m-xxs {
+    margin: .25rem;
+  }
+
+  .xl\:m-xs {
+    margin: .5rem;
+  }
+
+  .xl\:m-s {
+    margin: .75rem;
+  }
+
+  .xl\:m-m {
+    margin: 1rem;
+  }
+
+  .xl\:m-l {
+    margin: 1.5rem;
+  }
+
+  .xl\:m-xl {
+    margin: 2rem;
+  }
+
+  .xl\:m-xxl {
+    margin: 2.5rem;
+  }
+
+  .xl\:m-3xl {
+    margin: 3rem;
+  }
+
+  .xl\:m-4xl {
+    margin: 4rem;
+  }
+
+  .xl\:m-5xl {
+    margin: 8rem;
+  }
+
   .xl\:-m-0 {
     margin: 0px;
   }
@@ -72136,6 +83620,50 @@ video {
 
   .xl\:-m-3\.5 {
     margin: -0.875rem;
+  }
+
+  .xl\:-m-3xs {
+    margin: -0.125rem;
+  }
+
+  .xl\:-m-xxs {
+    margin: -0.25rem;
+  }
+
+  .xl\:-m-xs {
+    margin: -0.5rem;
+  }
+
+  .xl\:-m-s {
+    margin: -0.75rem;
+  }
+
+  .xl\:-m-m {
+    margin: -1rem;
+  }
+
+  .xl\:-m-l {
+    margin: -1.5rem;
+  }
+
+  .xl\:-m-xl {
+    margin: -2rem;
+  }
+
+  .xl\:-m-xxl {
+    margin: -2.5rem;
+  }
+
+  .xl\:-m-3xl {
+    margin: -3rem;
+  }
+
+  .xl\:-m-4xl {
+    margin: -4rem;
+  }
+
+  .xl\:-m-5xl {
+    margin: -8rem;
   }
 
   .xl\:my-0 {
@@ -72498,6 +84026,116 @@ video {
     margin-right: 0.875rem;
   }
 
+  .xl\:my-3xs {
+    margin-top: .125rem;
+    margin-bottom: .125rem;
+  }
+
+  .xl\:mx-3xs {
+    margin-left: .125rem;
+    margin-right: .125rem;
+  }
+
+  .xl\:my-xxs {
+    margin-top: .25rem;
+    margin-bottom: .25rem;
+  }
+
+  .xl\:mx-xxs {
+    margin-left: .25rem;
+    margin-right: .25rem;
+  }
+
+  .xl\:my-xs {
+    margin-top: .5rem;
+    margin-bottom: .5rem;
+  }
+
+  .xl\:mx-xs {
+    margin-left: .5rem;
+    margin-right: .5rem;
+  }
+
+  .xl\:my-s {
+    margin-top: .75rem;
+    margin-bottom: .75rem;
+  }
+
+  .xl\:mx-s {
+    margin-left: .75rem;
+    margin-right: .75rem;
+  }
+
+  .xl\:my-m {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .xl\:mx-m {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+
+  .xl\:my-l {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .xl\:mx-l {
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+
+  .xl\:my-xl {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .xl\:mx-xl {
+    margin-left: 2rem;
+    margin-right: 2rem;
+  }
+
+  .xl\:my-xxl {
+    margin-top: 2.5rem;
+    margin-bottom: 2.5rem;
+  }
+
+  .xl\:mx-xxl {
+    margin-left: 2.5rem;
+    margin-right: 2.5rem;
+  }
+
+  .xl\:my-3xl {
+    margin-top: 3rem;
+    margin-bottom: 3rem;
+  }
+
+  .xl\:mx-3xl {
+    margin-left: 3rem;
+    margin-right: 3rem;
+  }
+
+  .xl\:my-4xl {
+    margin-top: 4rem;
+    margin-bottom: 4rem;
+  }
+
+  .xl\:mx-4xl {
+    margin-left: 4rem;
+    margin-right: 4rem;
+  }
+
+  .xl\:my-5xl {
+    margin-top: 8rem;
+    margin-bottom: 8rem;
+  }
+
+  .xl\:mx-5xl {
+    margin-left: 8rem;
+    margin-right: 8rem;
+  }
+
   .xl\:-my-0 {
     margin-top: 0px;
     margin-bottom: 0px;
@@ -72846,6 +84484,116 @@ video {
   .xl\:-mx-3\.5 {
     margin-left: -0.875rem;
     margin-right: -0.875rem;
+  }
+
+  .xl\:-my-3xs {
+    margin-top: -0.125rem;
+    margin-bottom: -0.125rem;
+  }
+
+  .xl\:-mx-3xs {
+    margin-left: -0.125rem;
+    margin-right: -0.125rem;
+  }
+
+  .xl\:-my-xxs {
+    margin-top: -0.25rem;
+    margin-bottom: -0.25rem;
+  }
+
+  .xl\:-mx-xxs {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+  }
+
+  .xl\:-my-xs {
+    margin-top: -0.5rem;
+    margin-bottom: -0.5rem;
+  }
+
+  .xl\:-mx-xs {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+  }
+
+  .xl\:-my-s {
+    margin-top: -0.75rem;
+    margin-bottom: -0.75rem;
+  }
+
+  .xl\:-mx-s {
+    margin-left: -0.75rem;
+    margin-right: -0.75rem;
+  }
+
+  .xl\:-my-m {
+    margin-top: -1rem;
+    margin-bottom: -1rem;
+  }
+
+  .xl\:-mx-m {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+
+  .xl\:-my-l {
+    margin-top: -1.5rem;
+    margin-bottom: -1.5rem;
+  }
+
+  .xl\:-mx-l {
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+  }
+
+  .xl\:-my-xl {
+    margin-top: -2rem;
+    margin-bottom: -2rem;
+  }
+
+  .xl\:-mx-xl {
+    margin-left: -2rem;
+    margin-right: -2rem;
+  }
+
+  .xl\:-my-xxl {
+    margin-top: -2.5rem;
+    margin-bottom: -2.5rem;
+  }
+
+  .xl\:-mx-xxl {
+    margin-left: -2.5rem;
+    margin-right: -2.5rem;
+  }
+
+  .xl\:-my-3xl {
+    margin-top: -3rem;
+    margin-bottom: -3rem;
+  }
+
+  .xl\:-mx-3xl {
+    margin-left: -3rem;
+    margin-right: -3rem;
+  }
+
+  .xl\:-my-4xl {
+    margin-top: -4rem;
+    margin-bottom: -4rem;
+  }
+
+  .xl\:-mx-4xl {
+    margin-left: -4rem;
+    margin-right: -4rem;
+  }
+
+  .xl\:-my-5xl {
+    margin-top: -8rem;
+    margin-bottom: -8rem;
+  }
+
+  .xl\:-mx-5xl {
+    margin-left: -8rem;
+    margin-right: -8rem;
   }
 
   .xl\:mt-0 {
@@ -73424,6 +85172,182 @@ video {
     margin-left: 0.875rem;
   }
 
+  .xl\:mt-3xs {
+    margin-top: .125rem;
+  }
+
+  .xl\:mr-3xs {
+    margin-right: .125rem;
+  }
+
+  .xl\:mb-3xs {
+    margin-bottom: .125rem;
+  }
+
+  .xl\:ml-3xs {
+    margin-left: .125rem;
+  }
+
+  .xl\:mt-xxs {
+    margin-top: .25rem;
+  }
+
+  .xl\:mr-xxs {
+    margin-right: .25rem;
+  }
+
+  .xl\:mb-xxs {
+    margin-bottom: .25rem;
+  }
+
+  .xl\:ml-xxs {
+    margin-left: .25rem;
+  }
+
+  .xl\:mt-xs {
+    margin-top: .5rem;
+  }
+
+  .xl\:mr-xs {
+    margin-right: .5rem;
+  }
+
+  .xl\:mb-xs {
+    margin-bottom: .5rem;
+  }
+
+  .xl\:ml-xs {
+    margin-left: .5rem;
+  }
+
+  .xl\:mt-s {
+    margin-top: .75rem;
+  }
+
+  .xl\:mr-s {
+    margin-right: .75rem;
+  }
+
+  .xl\:mb-s {
+    margin-bottom: .75rem;
+  }
+
+  .xl\:ml-s {
+    margin-left: .75rem;
+  }
+
+  .xl\:mt-m {
+    margin-top: 1rem;
+  }
+
+  .xl\:mr-m {
+    margin-right: 1rem;
+  }
+
+  .xl\:mb-m {
+    margin-bottom: 1rem;
+  }
+
+  .xl\:ml-m {
+    margin-left: 1rem;
+  }
+
+  .xl\:mt-l {
+    margin-top: 1.5rem;
+  }
+
+  .xl\:mr-l {
+    margin-right: 1.5rem;
+  }
+
+  .xl\:mb-l {
+    margin-bottom: 1.5rem;
+  }
+
+  .xl\:ml-l {
+    margin-left: 1.5rem;
+  }
+
+  .xl\:mt-xl {
+    margin-top: 2rem;
+  }
+
+  .xl\:mr-xl {
+    margin-right: 2rem;
+  }
+
+  .xl\:mb-xl {
+    margin-bottom: 2rem;
+  }
+
+  .xl\:ml-xl {
+    margin-left: 2rem;
+  }
+
+  .xl\:mt-xxl {
+    margin-top: 2.5rem;
+  }
+
+  .xl\:mr-xxl {
+    margin-right: 2.5rem;
+  }
+
+  .xl\:mb-xxl {
+    margin-bottom: 2.5rem;
+  }
+
+  .xl\:ml-xxl {
+    margin-left: 2.5rem;
+  }
+
+  .xl\:mt-3xl {
+    margin-top: 3rem;
+  }
+
+  .xl\:mr-3xl {
+    margin-right: 3rem;
+  }
+
+  .xl\:mb-3xl {
+    margin-bottom: 3rem;
+  }
+
+  .xl\:ml-3xl {
+    margin-left: 3rem;
+  }
+
+  .xl\:mt-4xl {
+    margin-top: 4rem;
+  }
+
+  .xl\:mr-4xl {
+    margin-right: 4rem;
+  }
+
+  .xl\:mb-4xl {
+    margin-bottom: 4rem;
+  }
+
+  .xl\:ml-4xl {
+    margin-left: 4rem;
+  }
+
+  .xl\:mt-5xl {
+    margin-top: 8rem;
+  }
+
+  .xl\:mr-5xl {
+    margin-right: 8rem;
+  }
+
+  .xl\:mb-5xl {
+    margin-bottom: 8rem;
+  }
+
+  .xl\:ml-5xl {
+    margin-left: 8rem;
+  }
+
   .xl\:-mt-0 {
     margin-top: 0px;
   }
@@ -73984,6 +85908,182 @@ video {
     margin-left: -0.875rem;
   }
 
+  .xl\:-mt-3xs {
+    margin-top: -0.125rem;
+  }
+
+  .xl\:-mr-3xs {
+    margin-right: -0.125rem;
+  }
+
+  .xl\:-mb-3xs {
+    margin-bottom: -0.125rem;
+  }
+
+  .xl\:-ml-3xs {
+    margin-left: -0.125rem;
+  }
+
+  .xl\:-mt-xxs {
+    margin-top: -0.25rem;
+  }
+
+  .xl\:-mr-xxs {
+    margin-right: -0.25rem;
+  }
+
+  .xl\:-mb-xxs {
+    margin-bottom: -0.25rem;
+  }
+
+  .xl\:-ml-xxs {
+    margin-left: -0.25rem;
+  }
+
+  .xl\:-mt-xs {
+    margin-top: -0.5rem;
+  }
+
+  .xl\:-mr-xs {
+    margin-right: -0.5rem;
+  }
+
+  .xl\:-mb-xs {
+    margin-bottom: -0.5rem;
+  }
+
+  .xl\:-ml-xs {
+    margin-left: -0.5rem;
+  }
+
+  .xl\:-mt-s {
+    margin-top: -0.75rem;
+  }
+
+  .xl\:-mr-s {
+    margin-right: -0.75rem;
+  }
+
+  .xl\:-mb-s {
+    margin-bottom: -0.75rem;
+  }
+
+  .xl\:-ml-s {
+    margin-left: -0.75rem;
+  }
+
+  .xl\:-mt-m {
+    margin-top: -1rem;
+  }
+
+  .xl\:-mr-m {
+    margin-right: -1rem;
+  }
+
+  .xl\:-mb-m {
+    margin-bottom: -1rem;
+  }
+
+  .xl\:-ml-m {
+    margin-left: -1rem;
+  }
+
+  .xl\:-mt-l {
+    margin-top: -1.5rem;
+  }
+
+  .xl\:-mr-l {
+    margin-right: -1.5rem;
+  }
+
+  .xl\:-mb-l {
+    margin-bottom: -1.5rem;
+  }
+
+  .xl\:-ml-l {
+    margin-left: -1.5rem;
+  }
+
+  .xl\:-mt-xl {
+    margin-top: -2rem;
+  }
+
+  .xl\:-mr-xl {
+    margin-right: -2rem;
+  }
+
+  .xl\:-mb-xl {
+    margin-bottom: -2rem;
+  }
+
+  .xl\:-ml-xl {
+    margin-left: -2rem;
+  }
+
+  .xl\:-mt-xxl {
+    margin-top: -2.5rem;
+  }
+
+  .xl\:-mr-xxl {
+    margin-right: -2.5rem;
+  }
+
+  .xl\:-mb-xxl {
+    margin-bottom: -2.5rem;
+  }
+
+  .xl\:-ml-xxl {
+    margin-left: -2.5rem;
+  }
+
+  .xl\:-mt-3xl {
+    margin-top: -3rem;
+  }
+
+  .xl\:-mr-3xl {
+    margin-right: -3rem;
+  }
+
+  .xl\:-mb-3xl {
+    margin-bottom: -3rem;
+  }
+
+  .xl\:-ml-3xl {
+    margin-left: -3rem;
+  }
+
+  .xl\:-mt-4xl {
+    margin-top: -4rem;
+  }
+
+  .xl\:-mr-4xl {
+    margin-right: -4rem;
+  }
+
+  .xl\:-mb-4xl {
+    margin-bottom: -4rem;
+  }
+
+  .xl\:-ml-4xl {
+    margin-left: -4rem;
+  }
+
+  .xl\:-mt-5xl {
+    margin-top: -8rem;
+  }
+
+  .xl\:-mr-5xl {
+    margin-right: -8rem;
+  }
+
+  .xl\:-mb-5xl {
+    margin-bottom: -8rem;
+  }
+
+  .xl\:-ml-5xl {
+    margin-left: -8rem;
+  }
+
   .xl\:max-h-0 {
     max-height: 0px;
   }
@@ -74122,6 +86222,50 @@ video {
 
   .xl\:max-h-3\.5 {
     max-height: 0.875rem;
+  }
+
+  .xl\:max-h-3xs {
+    max-height: .125rem;
+  }
+
+  .xl\:max-h-xxs {
+    max-height: .25rem;
+  }
+
+  .xl\:max-h-xs {
+    max-height: .5rem;
+  }
+
+  .xl\:max-h-s {
+    max-height: .75rem;
+  }
+
+  .xl\:max-h-m {
+    max-height: 1rem;
+  }
+
+  .xl\:max-h-l {
+    max-height: 1.5rem;
+  }
+
+  .xl\:max-h-xl {
+    max-height: 2rem;
+  }
+
+  .xl\:max-h-xxl {
+    max-height: 2.5rem;
+  }
+
+  .xl\:max-h-3xl {
+    max-height: 3rem;
+  }
+
+  .xl\:max-h-4xl {
+    max-height: 4rem;
+  }
+
+  .xl\:max-h-5xl {
+    max-height: 8rem;
   }
 
   .xl\:max-h-full {
@@ -74898,6 +87042,50 @@ video {
     padding: 0.875rem;
   }
 
+  .xl\:p-3xs {
+    padding: .125rem;
+  }
+
+  .xl\:p-xxs {
+    padding: .25rem;
+  }
+
+  .xl\:p-xs {
+    padding: .5rem;
+  }
+
+  .xl\:p-s {
+    padding: .75rem;
+  }
+
+  .xl\:p-m {
+    padding: 1rem;
+  }
+
+  .xl\:p-l {
+    padding: 1.5rem;
+  }
+
+  .xl\:p-xl {
+    padding: 2rem;
+  }
+
+  .xl\:p-xxl {
+    padding: 2.5rem;
+  }
+
+  .xl\:p-3xl {
+    padding: 3rem;
+  }
+
+  .xl\:p-4xl {
+    padding: 4rem;
+  }
+
+  .xl\:p-5xl {
+    padding: 8rem;
+  }
+
   .xl\:py-0 {
     padding-top: 0px;
     padding-bottom: 0px;
@@ -75246,6 +87434,116 @@ video {
   .xl\:px-3\.5 {
     padding-left: 0.875rem;
     padding-right: 0.875rem;
+  }
+
+  .xl\:py-3xs {
+    padding-top: .125rem;
+    padding-bottom: .125rem;
+  }
+
+  .xl\:px-3xs {
+    padding-left: .125rem;
+    padding-right: .125rem;
+  }
+
+  .xl\:py-xxs {
+    padding-top: .25rem;
+    padding-bottom: .25rem;
+  }
+
+  .xl\:px-xxs {
+    padding-left: .25rem;
+    padding-right: .25rem;
+  }
+
+  .xl\:py-xs {
+    padding-top: .5rem;
+    padding-bottom: .5rem;
+  }
+
+  .xl\:px-xs {
+    padding-left: .5rem;
+    padding-right: .5rem;
+  }
+
+  .xl\:py-s {
+    padding-top: .75rem;
+    padding-bottom: .75rem;
+  }
+
+  .xl\:px-s {
+    padding-left: .75rem;
+    padding-right: .75rem;
+  }
+
+  .xl\:py-m {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .xl\:px-m {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .xl\:py-l {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .xl\:px-l {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .xl\:py-xl {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+
+  .xl\:px-xl {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
+  .xl\:py-xxl {
+    padding-top: 2.5rem;
+    padding-bottom: 2.5rem;
+  }
+
+  .xl\:px-xxl {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+  }
+
+  .xl\:py-3xl {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+
+  .xl\:px-3xl {
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
+
+  .xl\:py-4xl {
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+  }
+
+  .xl\:px-4xl {
+    padding-left: 4rem;
+    padding-right: 4rem;
+  }
+
+  .xl\:py-5xl {
+    padding-top: 8rem;
+    padding-bottom: 8rem;
+  }
+
+  .xl\:px-5xl {
+    padding-left: 8rem;
+    padding-right: 8rem;
   }
 
   .xl\:pt-0 {
@@ -75806,6 +88104,182 @@ video {
 
   .xl\:pl-3\.5 {
     padding-left: 0.875rem;
+  }
+
+  .xl\:pt-3xs {
+    padding-top: .125rem;
+  }
+
+  .xl\:pr-3xs {
+    padding-right: .125rem;
+  }
+
+  .xl\:pb-3xs {
+    padding-bottom: .125rem;
+  }
+
+  .xl\:pl-3xs {
+    padding-left: .125rem;
+  }
+
+  .xl\:pt-xxs {
+    padding-top: .25rem;
+  }
+
+  .xl\:pr-xxs {
+    padding-right: .25rem;
+  }
+
+  .xl\:pb-xxs {
+    padding-bottom: .25rem;
+  }
+
+  .xl\:pl-xxs {
+    padding-left: .25rem;
+  }
+
+  .xl\:pt-xs {
+    padding-top: .5rem;
+  }
+
+  .xl\:pr-xs {
+    padding-right: .5rem;
+  }
+
+  .xl\:pb-xs {
+    padding-bottom: .5rem;
+  }
+
+  .xl\:pl-xs {
+    padding-left: .5rem;
+  }
+
+  .xl\:pt-s {
+    padding-top: .75rem;
+  }
+
+  .xl\:pr-s {
+    padding-right: .75rem;
+  }
+
+  .xl\:pb-s {
+    padding-bottom: .75rem;
+  }
+
+  .xl\:pl-s {
+    padding-left: .75rem;
+  }
+
+  .xl\:pt-m {
+    padding-top: 1rem;
+  }
+
+  .xl\:pr-m {
+    padding-right: 1rem;
+  }
+
+  .xl\:pb-m {
+    padding-bottom: 1rem;
+  }
+
+  .xl\:pl-m {
+    padding-left: 1rem;
+  }
+
+  .xl\:pt-l {
+    padding-top: 1.5rem;
+  }
+
+  .xl\:pr-l {
+    padding-right: 1.5rem;
+  }
+
+  .xl\:pb-l {
+    padding-bottom: 1.5rem;
+  }
+
+  .xl\:pl-l {
+    padding-left: 1.5rem;
+  }
+
+  .xl\:pt-xl {
+    padding-top: 2rem;
+  }
+
+  .xl\:pr-xl {
+    padding-right: 2rem;
+  }
+
+  .xl\:pb-xl {
+    padding-bottom: 2rem;
+  }
+
+  .xl\:pl-xl {
+    padding-left: 2rem;
+  }
+
+  .xl\:pt-xxl {
+    padding-top: 2.5rem;
+  }
+
+  .xl\:pr-xxl {
+    padding-right: 2.5rem;
+  }
+
+  .xl\:pb-xxl {
+    padding-bottom: 2.5rem;
+  }
+
+  .xl\:pl-xxl {
+    padding-left: 2.5rem;
+  }
+
+  .xl\:pt-3xl {
+    padding-top: 3rem;
+  }
+
+  .xl\:pr-3xl {
+    padding-right: 3rem;
+  }
+
+  .xl\:pb-3xl {
+    padding-bottom: 3rem;
+  }
+
+  .xl\:pl-3xl {
+    padding-left: 3rem;
+  }
+
+  .xl\:pt-4xl {
+    padding-top: 4rem;
+  }
+
+  .xl\:pr-4xl {
+    padding-right: 4rem;
+  }
+
+  .xl\:pb-4xl {
+    padding-bottom: 4rem;
+  }
+
+  .xl\:pl-4xl {
+    padding-left: 4rem;
+  }
+
+  .xl\:pt-5xl {
+    padding-top: 8rem;
+  }
+
+  .xl\:pr-5xl {
+    padding-right: 8rem;
+  }
+
+  .xl\:pb-5xl {
+    padding-bottom: 8rem;
+  }
+
+  .xl\:pl-5xl {
+    padding-left: 8rem;
   }
 
   .xl\:placeholder-primary::-moz-placeholder {
@@ -76689,6 +89163,83 @@ video {
     left: 0.875rem;
   }
 
+  .xl\:inset-3xs {
+    top: .125rem;
+    right: .125rem;
+    bottom: .125rem;
+    left: .125rem;
+  }
+
+  .xl\:inset-xxs {
+    top: .25rem;
+    right: .25rem;
+    bottom: .25rem;
+    left: .25rem;
+  }
+
+  .xl\:inset-xs {
+    top: .5rem;
+    right: .5rem;
+    bottom: .5rem;
+    left: .5rem;
+  }
+
+  .xl\:inset-s {
+    top: .75rem;
+    right: .75rem;
+    bottom: .75rem;
+    left: .75rem;
+  }
+
+  .xl\:inset-m {
+    top: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    left: 1rem;
+  }
+
+  .xl\:inset-l {
+    top: 1.5rem;
+    right: 1.5rem;
+    bottom: 1.5rem;
+    left: 1.5rem;
+  }
+
+  .xl\:inset-xl {
+    top: 2rem;
+    right: 2rem;
+    bottom: 2rem;
+    left: 2rem;
+  }
+
+  .xl\:inset-xxl {
+    top: 2.5rem;
+    right: 2.5rem;
+    bottom: 2.5rem;
+    left: 2.5rem;
+  }
+
+  .xl\:inset-3xl {
+    top: 3rem;
+    right: 3rem;
+    bottom: 3rem;
+    left: 3rem;
+  }
+
+  .xl\:inset-4xl {
+    top: 4rem;
+    right: 4rem;
+    bottom: 4rem;
+    left: 4rem;
+  }
+
+  .xl\:inset-5xl {
+    top: 8rem;
+    right: 8rem;
+    bottom: 8rem;
+    left: 8rem;
+  }
+
   .xl\:-inset-0 {
     top: 0px;
     right: 0px;
@@ -76932,6 +89483,83 @@ video {
     right: -0.875rem;
     bottom: -0.875rem;
     left: -0.875rem;
+  }
+
+  .xl\:-inset-3xs {
+    top: -0.125rem;
+    right: -0.125rem;
+    bottom: -0.125rem;
+    left: -0.125rem;
+  }
+
+  .xl\:-inset-xxs {
+    top: -0.25rem;
+    right: -0.25rem;
+    bottom: -0.25rem;
+    left: -0.25rem;
+  }
+
+  .xl\:-inset-xs {
+    top: -0.5rem;
+    right: -0.5rem;
+    bottom: -0.5rem;
+    left: -0.5rem;
+  }
+
+  .xl\:-inset-s {
+    top: -0.75rem;
+    right: -0.75rem;
+    bottom: -0.75rem;
+    left: -0.75rem;
+  }
+
+  .xl\:-inset-m {
+    top: -1rem;
+    right: -1rem;
+    bottom: -1rem;
+    left: -1rem;
+  }
+
+  .xl\:-inset-l {
+    top: -1.5rem;
+    right: -1.5rem;
+    bottom: -1.5rem;
+    left: -1.5rem;
+  }
+
+  .xl\:-inset-xl {
+    top: -2rem;
+    right: -2rem;
+    bottom: -2rem;
+    left: -2rem;
+  }
+
+  .xl\:-inset-xxl {
+    top: -2.5rem;
+    right: -2.5rem;
+    bottom: -2.5rem;
+    left: -2.5rem;
+  }
+
+  .xl\:-inset-3xl {
+    top: -3rem;
+    right: -3rem;
+    bottom: -3rem;
+    left: -3rem;
+  }
+
+  .xl\:-inset-4xl {
+    top: -4rem;
+    right: -4rem;
+    bottom: -4rem;
+    left: -4rem;
+  }
+
+  .xl\:-inset-5xl {
+    top: -8rem;
+    right: -8rem;
+    bottom: -8rem;
+    left: -8rem;
   }
 
   .xl\:inset-1\/2 {
@@ -77392,6 +90020,116 @@ video {
     left: 0.875rem;
   }
 
+  .xl\:inset-y-3xs {
+    top: .125rem;
+    bottom: .125rem;
+  }
+
+  .xl\:inset-x-3xs {
+    right: .125rem;
+    left: .125rem;
+  }
+
+  .xl\:inset-y-xxs {
+    top: .25rem;
+    bottom: .25rem;
+  }
+
+  .xl\:inset-x-xxs {
+    right: .25rem;
+    left: .25rem;
+  }
+
+  .xl\:inset-y-xs {
+    top: .5rem;
+    bottom: .5rem;
+  }
+
+  .xl\:inset-x-xs {
+    right: .5rem;
+    left: .5rem;
+  }
+
+  .xl\:inset-y-s {
+    top: .75rem;
+    bottom: .75rem;
+  }
+
+  .xl\:inset-x-s {
+    right: .75rem;
+    left: .75rem;
+  }
+
+  .xl\:inset-y-m {
+    top: 1rem;
+    bottom: 1rem;
+  }
+
+  .xl\:inset-x-m {
+    right: 1rem;
+    left: 1rem;
+  }
+
+  .xl\:inset-y-l {
+    top: 1.5rem;
+    bottom: 1.5rem;
+  }
+
+  .xl\:inset-x-l {
+    right: 1.5rem;
+    left: 1.5rem;
+  }
+
+  .xl\:inset-y-xl {
+    top: 2rem;
+    bottom: 2rem;
+  }
+
+  .xl\:inset-x-xl {
+    right: 2rem;
+    left: 2rem;
+  }
+
+  .xl\:inset-y-xxl {
+    top: 2.5rem;
+    bottom: 2.5rem;
+  }
+
+  .xl\:inset-x-xxl {
+    right: 2.5rem;
+    left: 2.5rem;
+  }
+
+  .xl\:inset-y-3xl {
+    top: 3rem;
+    bottom: 3rem;
+  }
+
+  .xl\:inset-x-3xl {
+    right: 3rem;
+    left: 3rem;
+  }
+
+  .xl\:inset-y-4xl {
+    top: 4rem;
+    bottom: 4rem;
+  }
+
+  .xl\:inset-x-4xl {
+    right: 4rem;
+    left: 4rem;
+  }
+
+  .xl\:inset-y-5xl {
+    top: 8rem;
+    bottom: 8rem;
+  }
+
+  .xl\:inset-x-5xl {
+    right: 8rem;
+    left: 8rem;
+  }
+
   .xl\:-inset-y-0 {
     top: 0px;
     bottom: 0px;
@@ -77740,6 +90478,116 @@ video {
   .xl\:-inset-x-3\.5 {
     right: -0.875rem;
     left: -0.875rem;
+  }
+
+  .xl\:-inset-y-3xs {
+    top: -0.125rem;
+    bottom: -0.125rem;
+  }
+
+  .xl\:-inset-x-3xs {
+    right: -0.125rem;
+    left: -0.125rem;
+  }
+
+  .xl\:-inset-y-xxs {
+    top: -0.25rem;
+    bottom: -0.25rem;
+  }
+
+  .xl\:-inset-x-xxs {
+    right: -0.25rem;
+    left: -0.25rem;
+  }
+
+  .xl\:-inset-y-xs {
+    top: -0.5rem;
+    bottom: -0.5rem;
+  }
+
+  .xl\:-inset-x-xs {
+    right: -0.5rem;
+    left: -0.5rem;
+  }
+
+  .xl\:-inset-y-s {
+    top: -0.75rem;
+    bottom: -0.75rem;
+  }
+
+  .xl\:-inset-x-s {
+    right: -0.75rem;
+    left: -0.75rem;
+  }
+
+  .xl\:-inset-y-m {
+    top: -1rem;
+    bottom: -1rem;
+  }
+
+  .xl\:-inset-x-m {
+    right: -1rem;
+    left: -1rem;
+  }
+
+  .xl\:-inset-y-l {
+    top: -1.5rem;
+    bottom: -1.5rem;
+  }
+
+  .xl\:-inset-x-l {
+    right: -1.5rem;
+    left: -1.5rem;
+  }
+
+  .xl\:-inset-y-xl {
+    top: -2rem;
+    bottom: -2rem;
+  }
+
+  .xl\:-inset-x-xl {
+    right: -2rem;
+    left: -2rem;
+  }
+
+  .xl\:-inset-y-xxl {
+    top: -2.5rem;
+    bottom: -2.5rem;
+  }
+
+  .xl\:-inset-x-xxl {
+    right: -2.5rem;
+    left: -2.5rem;
+  }
+
+  .xl\:-inset-y-3xl {
+    top: -3rem;
+    bottom: -3rem;
+  }
+
+  .xl\:-inset-x-3xl {
+    right: -3rem;
+    left: -3rem;
+  }
+
+  .xl\:-inset-y-4xl {
+    top: -4rem;
+    bottom: -4rem;
+  }
+
+  .xl\:-inset-x-4xl {
+    right: -4rem;
+    left: -4rem;
+  }
+
+  .xl\:-inset-y-5xl {
+    top: -8rem;
+    bottom: -8rem;
+  }
+
+  .xl\:-inset-x-5xl {
+    right: -8rem;
+    left: -8rem;
   }
 
   .xl\:inset-y-1\/2 {
@@ -78458,6 +91306,182 @@ video {
     left: 0.875rem;
   }
 
+  .xl\:top-3xs {
+    top: .125rem;
+  }
+
+  .xl\:right-3xs {
+    right: .125rem;
+  }
+
+  .xl\:bottom-3xs {
+    bottom: .125rem;
+  }
+
+  .xl\:left-3xs {
+    left: .125rem;
+  }
+
+  .xl\:top-xxs {
+    top: .25rem;
+  }
+
+  .xl\:right-xxs {
+    right: .25rem;
+  }
+
+  .xl\:bottom-xxs {
+    bottom: .25rem;
+  }
+
+  .xl\:left-xxs {
+    left: .25rem;
+  }
+
+  .xl\:top-xs {
+    top: .5rem;
+  }
+
+  .xl\:right-xs {
+    right: .5rem;
+  }
+
+  .xl\:bottom-xs {
+    bottom: .5rem;
+  }
+
+  .xl\:left-xs {
+    left: .5rem;
+  }
+
+  .xl\:top-s {
+    top: .75rem;
+  }
+
+  .xl\:right-s {
+    right: .75rem;
+  }
+
+  .xl\:bottom-s {
+    bottom: .75rem;
+  }
+
+  .xl\:left-s {
+    left: .75rem;
+  }
+
+  .xl\:top-m {
+    top: 1rem;
+  }
+
+  .xl\:right-m {
+    right: 1rem;
+  }
+
+  .xl\:bottom-m {
+    bottom: 1rem;
+  }
+
+  .xl\:left-m {
+    left: 1rem;
+  }
+
+  .xl\:top-l {
+    top: 1.5rem;
+  }
+
+  .xl\:right-l {
+    right: 1.5rem;
+  }
+
+  .xl\:bottom-l {
+    bottom: 1.5rem;
+  }
+
+  .xl\:left-l {
+    left: 1.5rem;
+  }
+
+  .xl\:top-xl {
+    top: 2rem;
+  }
+
+  .xl\:right-xl {
+    right: 2rem;
+  }
+
+  .xl\:bottom-xl {
+    bottom: 2rem;
+  }
+
+  .xl\:left-xl {
+    left: 2rem;
+  }
+
+  .xl\:top-xxl {
+    top: 2.5rem;
+  }
+
+  .xl\:right-xxl {
+    right: 2.5rem;
+  }
+
+  .xl\:bottom-xxl {
+    bottom: 2.5rem;
+  }
+
+  .xl\:left-xxl {
+    left: 2.5rem;
+  }
+
+  .xl\:top-3xl {
+    top: 3rem;
+  }
+
+  .xl\:right-3xl {
+    right: 3rem;
+  }
+
+  .xl\:bottom-3xl {
+    bottom: 3rem;
+  }
+
+  .xl\:left-3xl {
+    left: 3rem;
+  }
+
+  .xl\:top-4xl {
+    top: 4rem;
+  }
+
+  .xl\:right-4xl {
+    right: 4rem;
+  }
+
+  .xl\:bottom-4xl {
+    bottom: 4rem;
+  }
+
+  .xl\:left-4xl {
+    left: 4rem;
+  }
+
+  .xl\:top-5xl {
+    top: 8rem;
+  }
+
+  .xl\:right-5xl {
+    right: 8rem;
+  }
+
+  .xl\:bottom-5xl {
+    bottom: 8rem;
+  }
+
+  .xl\:left-5xl {
+    left: 8rem;
+  }
+
   .xl\:-top-0 {
     top: 0px;
   }
@@ -79016,6 +92040,182 @@ video {
 
   .xl\:-left-3\.5 {
     left: -0.875rem;
+  }
+
+  .xl\:-top-3xs {
+    top: -0.125rem;
+  }
+
+  .xl\:-right-3xs {
+    right: -0.125rem;
+  }
+
+  .xl\:-bottom-3xs {
+    bottom: -0.125rem;
+  }
+
+  .xl\:-left-3xs {
+    left: -0.125rem;
+  }
+
+  .xl\:-top-xxs {
+    top: -0.25rem;
+  }
+
+  .xl\:-right-xxs {
+    right: -0.25rem;
+  }
+
+  .xl\:-bottom-xxs {
+    bottom: -0.25rem;
+  }
+
+  .xl\:-left-xxs {
+    left: -0.25rem;
+  }
+
+  .xl\:-top-xs {
+    top: -0.5rem;
+  }
+
+  .xl\:-right-xs {
+    right: -0.5rem;
+  }
+
+  .xl\:-bottom-xs {
+    bottom: -0.5rem;
+  }
+
+  .xl\:-left-xs {
+    left: -0.5rem;
+  }
+
+  .xl\:-top-s {
+    top: -0.75rem;
+  }
+
+  .xl\:-right-s {
+    right: -0.75rem;
+  }
+
+  .xl\:-bottom-s {
+    bottom: -0.75rem;
+  }
+
+  .xl\:-left-s {
+    left: -0.75rem;
+  }
+
+  .xl\:-top-m {
+    top: -1rem;
+  }
+
+  .xl\:-right-m {
+    right: -1rem;
+  }
+
+  .xl\:-bottom-m {
+    bottom: -1rem;
+  }
+
+  .xl\:-left-m {
+    left: -1rem;
+  }
+
+  .xl\:-top-l {
+    top: -1.5rem;
+  }
+
+  .xl\:-right-l {
+    right: -1.5rem;
+  }
+
+  .xl\:-bottom-l {
+    bottom: -1.5rem;
+  }
+
+  .xl\:-left-l {
+    left: -1.5rem;
+  }
+
+  .xl\:-top-xl {
+    top: -2rem;
+  }
+
+  .xl\:-right-xl {
+    right: -2rem;
+  }
+
+  .xl\:-bottom-xl {
+    bottom: -2rem;
+  }
+
+  .xl\:-left-xl {
+    left: -2rem;
+  }
+
+  .xl\:-top-xxl {
+    top: -2.5rem;
+  }
+
+  .xl\:-right-xxl {
+    right: -2.5rem;
+  }
+
+  .xl\:-bottom-xxl {
+    bottom: -2.5rem;
+  }
+
+  .xl\:-left-xxl {
+    left: -2.5rem;
+  }
+
+  .xl\:-top-3xl {
+    top: -3rem;
+  }
+
+  .xl\:-right-3xl {
+    right: -3rem;
+  }
+
+  .xl\:-bottom-3xl {
+    bottom: -3rem;
+  }
+
+  .xl\:-left-3xl {
+    left: -3rem;
+  }
+
+  .xl\:-top-4xl {
+    top: -4rem;
+  }
+
+  .xl\:-right-4xl {
+    right: -4rem;
+  }
+
+  .xl\:-bottom-4xl {
+    bottom: -4rem;
+  }
+
+  .xl\:-left-4xl {
+    left: -4rem;
+  }
+
+  .xl\:-top-5xl {
+    top: -8rem;
+  }
+
+  .xl\:-right-5xl {
+    right: -8rem;
+  }
+
+  .xl\:-bottom-5xl {
+    bottom: -8rem;
+  }
+
+  .xl\:-left-5xl {
+    left: -8rem;
   }
 
   .xl\:top-1\/2 {
@@ -80891,6 +94091,50 @@ video {
     width: 0.875rem;
   }
 
+  .xl\:w-3xs {
+    width: .125rem;
+  }
+
+  .xl\:w-xxs {
+    width: .25rem;
+  }
+
+  .xl\:w-xs {
+    width: .5rem;
+  }
+
+  .xl\:w-s {
+    width: .75rem;
+  }
+
+  .xl\:w-m {
+    width: 1rem;
+  }
+
+  .xl\:w-l {
+    width: 1.5rem;
+  }
+
+  .xl\:w-xl {
+    width: 2rem;
+  }
+
+  .xl\:w-xxl {
+    width: 2.5rem;
+  }
+
+  .xl\:w-3xl {
+    width: 3rem;
+  }
+
+  .xl\:w-4xl {
+    width: 4rem;
+  }
+
+  .xl\:w-5xl {
+    width: 8rem;
+  }
+
   .xl\:w-1\/2 {
     width: 50%;
   }
@@ -81239,6 +94483,50 @@ video {
     gap: 0.875rem;
   }
 
+  .xl\:gap-3xs {
+    gap: .125rem;
+  }
+
+  .xl\:gap-xxs {
+    gap: .25rem;
+  }
+
+  .xl\:gap-xs {
+    gap: .5rem;
+  }
+
+  .xl\:gap-s {
+    gap: .75rem;
+  }
+
+  .xl\:gap-m {
+    gap: 1rem;
+  }
+
+  .xl\:gap-l {
+    gap: 1.5rem;
+  }
+
+  .xl\:gap-xl {
+    gap: 2rem;
+  }
+
+  .xl\:gap-xxl {
+    gap: 2.5rem;
+  }
+
+  .xl\:gap-3xl {
+    gap: 3rem;
+  }
+
+  .xl\:gap-4xl {
+    gap: 4rem;
+  }
+
+  .xl\:gap-5xl {
+    gap: 8rem;
+  }
+
   .xl\:gap-x-0 {
     -moz-column-gap: 0px;
          column-gap: 0px;
@@ -81414,6 +94702,61 @@ video {
          column-gap: 0.875rem;
   }
 
+  .xl\:gap-x-3xs {
+    -moz-column-gap: .125rem;
+         column-gap: .125rem;
+  }
+
+  .xl\:gap-x-xxs {
+    -moz-column-gap: .25rem;
+         column-gap: .25rem;
+  }
+
+  .xl\:gap-x-xs {
+    -moz-column-gap: .5rem;
+         column-gap: .5rem;
+  }
+
+  .xl\:gap-x-s {
+    -moz-column-gap: .75rem;
+         column-gap: .75rem;
+  }
+
+  .xl\:gap-x-m {
+    -moz-column-gap: 1rem;
+         column-gap: 1rem;
+  }
+
+  .xl\:gap-x-l {
+    -moz-column-gap: 1.5rem;
+         column-gap: 1.5rem;
+  }
+
+  .xl\:gap-x-xl {
+    -moz-column-gap: 2rem;
+         column-gap: 2rem;
+  }
+
+  .xl\:gap-x-xxl {
+    -moz-column-gap: 2.5rem;
+         column-gap: 2.5rem;
+  }
+
+  .xl\:gap-x-3xl {
+    -moz-column-gap: 3rem;
+         column-gap: 3rem;
+  }
+
+  .xl\:gap-x-4xl {
+    -moz-column-gap: 4rem;
+         column-gap: 4rem;
+  }
+
+  .xl\:gap-x-5xl {
+    -moz-column-gap: 8rem;
+         column-gap: 8rem;
+  }
+
   .xl\:gap-y-0 {
     row-gap: 0px;
   }
@@ -81552,6 +94895,50 @@ video {
 
   .xl\:gap-y-3\.5 {
     row-gap: 0.875rem;
+  }
+
+  .xl\:gap-y-3xs {
+    row-gap: .125rem;
+  }
+
+  .xl\:gap-y-xxs {
+    row-gap: .25rem;
+  }
+
+  .xl\:gap-y-xs {
+    row-gap: .5rem;
+  }
+
+  .xl\:gap-y-s {
+    row-gap: .75rem;
+  }
+
+  .xl\:gap-y-m {
+    row-gap: 1rem;
+  }
+
+  .xl\:gap-y-l {
+    row-gap: 1.5rem;
+  }
+
+  .xl\:gap-y-xl {
+    row-gap: 2rem;
+  }
+
+  .xl\:gap-y-xxl {
+    row-gap: 2.5rem;
+  }
+
+  .xl\:gap-y-3xl {
+    row-gap: 3rem;
+  }
+
+  .xl\:gap-y-4xl {
+    row-gap: 4rem;
+  }
+
+  .xl\:gap-y-5xl {
+    row-gap: 8rem;
   }
 
   .xl\:grid-flow-row {
@@ -82746,6 +96133,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .xl\:translate-x-3xs {
+    --tw-translate-x: .125rem;
+  }
+
+  .xl\:translate-x-xxs {
+    --tw-translate-x: .25rem;
+  }
+
+  .xl\:translate-x-xs {
+    --tw-translate-x: .5rem;
+  }
+
+  .xl\:translate-x-s {
+    --tw-translate-x: .75rem;
+  }
+
+  .xl\:translate-x-m {
+    --tw-translate-x: 1rem;
+  }
+
+  .xl\:translate-x-l {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .xl\:translate-x-xl {
+    --tw-translate-x: 2rem;
+  }
+
+  .xl\:translate-x-xxl {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .xl\:translate-x-3xl {
+    --tw-translate-x: 3rem;
+  }
+
+  .xl\:translate-x-4xl {
+    --tw-translate-x: 4rem;
+  }
+
+  .xl\:translate-x-5xl {
+    --tw-translate-x: 8rem;
+  }
+
   .xl\:-translate-x-0 {
     --tw-translate-x: 0px;
   }
@@ -82884,6 +96315,50 @@ video {
 
   .xl\:-translate-x-3\.5 {
     --tw-translate-x: -0.875rem;
+  }
+
+  .xl\:-translate-x-3xs {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .xl\:-translate-x-xxs {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .xl\:-translate-x-xs {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .xl\:-translate-x-s {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .xl\:-translate-x-m {
+    --tw-translate-x: -1rem;
+  }
+
+  .xl\:-translate-x-l {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .xl\:-translate-x-xl {
+    --tw-translate-x: -2rem;
+  }
+
+  .xl\:-translate-x-xxl {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .xl\:-translate-x-3xl {
+    --tw-translate-x: -3rem;
+  }
+
+  .xl\:-translate-x-4xl {
+    --tw-translate-x: -4rem;
+  }
+
+  .xl\:-translate-x-5xl {
+    --tw-translate-x: -8rem;
   }
 
   .xl\:translate-x-1\/2 {
@@ -83082,6 +96557,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .xl\:translate-y-3xs {
+    --tw-translate-y: .125rem;
+  }
+
+  .xl\:translate-y-xxs {
+    --tw-translate-y: .25rem;
+  }
+
+  .xl\:translate-y-xs {
+    --tw-translate-y: .5rem;
+  }
+
+  .xl\:translate-y-s {
+    --tw-translate-y: .75rem;
+  }
+
+  .xl\:translate-y-m {
+    --tw-translate-y: 1rem;
+  }
+
+  .xl\:translate-y-l {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .xl\:translate-y-xl {
+    --tw-translate-y: 2rem;
+  }
+
+  .xl\:translate-y-xxl {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .xl\:translate-y-3xl {
+    --tw-translate-y: 3rem;
+  }
+
+  .xl\:translate-y-4xl {
+    --tw-translate-y: 4rem;
+  }
+
+  .xl\:translate-y-5xl {
+    --tw-translate-y: 8rem;
+  }
+
   .xl\:-translate-y-0 {
     --tw-translate-y: 0px;
   }
@@ -83220,6 +96739,50 @@ video {
 
   .xl\:-translate-y-3\.5 {
     --tw-translate-y: -0.875rem;
+  }
+
+  .xl\:-translate-y-3xs {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .xl\:-translate-y-xxs {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .xl\:-translate-y-xs {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .xl\:-translate-y-s {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .xl\:-translate-y-m {
+    --tw-translate-y: -1rem;
+  }
+
+  .xl\:-translate-y-l {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .xl\:-translate-y-xl {
+    --tw-translate-y: -2rem;
+  }
+
+  .xl\:-translate-y-xxl {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .xl\:-translate-y-3xl {
+    --tw-translate-y: -3rem;
+  }
+
+  .xl\:-translate-y-4xl {
+    --tw-translate-y: -4rem;
+  }
+
+  .xl\:-translate-y-5xl {
+    --tw-translate-y: -8rem;
   }
 
   .xl\:translate-y-1\/2 {
@@ -83418,6 +96981,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .xl\:hover\:translate-x-3xs:hover {
+    --tw-translate-x: .125rem;
+  }
+
+  .xl\:hover\:translate-x-xxs:hover {
+    --tw-translate-x: .25rem;
+  }
+
+  .xl\:hover\:translate-x-xs:hover {
+    --tw-translate-x: .5rem;
+  }
+
+  .xl\:hover\:translate-x-s:hover {
+    --tw-translate-x: .75rem;
+  }
+
+  .xl\:hover\:translate-x-m:hover {
+    --tw-translate-x: 1rem;
+  }
+
+  .xl\:hover\:translate-x-l:hover {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .xl\:hover\:translate-x-xl:hover {
+    --tw-translate-x: 2rem;
+  }
+
+  .xl\:hover\:translate-x-xxl:hover {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .xl\:hover\:translate-x-3xl:hover {
+    --tw-translate-x: 3rem;
+  }
+
+  .xl\:hover\:translate-x-4xl:hover {
+    --tw-translate-x: 4rem;
+  }
+
+  .xl\:hover\:translate-x-5xl:hover {
+    --tw-translate-x: 8rem;
+  }
+
   .xl\:hover\:-translate-x-0:hover {
     --tw-translate-x: 0px;
   }
@@ -83556,6 +97163,50 @@ video {
 
   .xl\:hover\:-translate-x-3\.5:hover {
     --tw-translate-x: -0.875rem;
+  }
+
+  .xl\:hover\:-translate-x-3xs:hover {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .xl\:hover\:-translate-x-xxs:hover {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .xl\:hover\:-translate-x-xs:hover {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .xl\:hover\:-translate-x-s:hover {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .xl\:hover\:-translate-x-m:hover {
+    --tw-translate-x: -1rem;
+  }
+
+  .xl\:hover\:-translate-x-l:hover {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .xl\:hover\:-translate-x-xl:hover {
+    --tw-translate-x: -2rem;
+  }
+
+  .xl\:hover\:-translate-x-xxl:hover {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .xl\:hover\:-translate-x-3xl:hover {
+    --tw-translate-x: -3rem;
+  }
+
+  .xl\:hover\:-translate-x-4xl:hover {
+    --tw-translate-x: -4rem;
+  }
+
+  .xl\:hover\:-translate-x-5xl:hover {
+    --tw-translate-x: -8rem;
   }
 
   .xl\:hover\:translate-x-1\/2:hover {
@@ -83754,6 +97405,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .xl\:hover\:translate-y-3xs:hover {
+    --tw-translate-y: .125rem;
+  }
+
+  .xl\:hover\:translate-y-xxs:hover {
+    --tw-translate-y: .25rem;
+  }
+
+  .xl\:hover\:translate-y-xs:hover {
+    --tw-translate-y: .5rem;
+  }
+
+  .xl\:hover\:translate-y-s:hover {
+    --tw-translate-y: .75rem;
+  }
+
+  .xl\:hover\:translate-y-m:hover {
+    --tw-translate-y: 1rem;
+  }
+
+  .xl\:hover\:translate-y-l:hover {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .xl\:hover\:translate-y-xl:hover {
+    --tw-translate-y: 2rem;
+  }
+
+  .xl\:hover\:translate-y-xxl:hover {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .xl\:hover\:translate-y-3xl:hover {
+    --tw-translate-y: 3rem;
+  }
+
+  .xl\:hover\:translate-y-4xl:hover {
+    --tw-translate-y: 4rem;
+  }
+
+  .xl\:hover\:translate-y-5xl:hover {
+    --tw-translate-y: 8rem;
+  }
+
   .xl\:hover\:-translate-y-0:hover {
     --tw-translate-y: 0px;
   }
@@ -83892,6 +97587,50 @@ video {
 
   .xl\:hover\:-translate-y-3\.5:hover {
     --tw-translate-y: -0.875rem;
+  }
+
+  .xl\:hover\:-translate-y-3xs:hover {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .xl\:hover\:-translate-y-xxs:hover {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .xl\:hover\:-translate-y-xs:hover {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .xl\:hover\:-translate-y-s:hover {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .xl\:hover\:-translate-y-m:hover {
+    --tw-translate-y: -1rem;
+  }
+
+  .xl\:hover\:-translate-y-l:hover {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .xl\:hover\:-translate-y-xl:hover {
+    --tw-translate-y: -2rem;
+  }
+
+  .xl\:hover\:-translate-y-xxl:hover {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .xl\:hover\:-translate-y-3xl:hover {
+    --tw-translate-y: -3rem;
+  }
+
+  .xl\:hover\:-translate-y-4xl:hover {
+    --tw-translate-y: -4rem;
+  }
+
+  .xl\:hover\:-translate-y-5xl:hover {
+    --tw-translate-y: -8rem;
   }
 
   .xl\:hover\:translate-y-1\/2:hover {
@@ -84090,6 +97829,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .xl\:focus\:translate-x-3xs:focus {
+    --tw-translate-x: .125rem;
+  }
+
+  .xl\:focus\:translate-x-xxs:focus {
+    --tw-translate-x: .25rem;
+  }
+
+  .xl\:focus\:translate-x-xs:focus {
+    --tw-translate-x: .5rem;
+  }
+
+  .xl\:focus\:translate-x-s:focus {
+    --tw-translate-x: .75rem;
+  }
+
+  .xl\:focus\:translate-x-m:focus {
+    --tw-translate-x: 1rem;
+  }
+
+  .xl\:focus\:translate-x-l:focus {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .xl\:focus\:translate-x-xl:focus {
+    --tw-translate-x: 2rem;
+  }
+
+  .xl\:focus\:translate-x-xxl:focus {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .xl\:focus\:translate-x-3xl:focus {
+    --tw-translate-x: 3rem;
+  }
+
+  .xl\:focus\:translate-x-4xl:focus {
+    --tw-translate-x: 4rem;
+  }
+
+  .xl\:focus\:translate-x-5xl:focus {
+    --tw-translate-x: 8rem;
+  }
+
   .xl\:focus\:-translate-x-0:focus {
     --tw-translate-x: 0px;
   }
@@ -84228,6 +98011,50 @@ video {
 
   .xl\:focus\:-translate-x-3\.5:focus {
     --tw-translate-x: -0.875rem;
+  }
+
+  .xl\:focus\:-translate-x-3xs:focus {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .xl\:focus\:-translate-x-xxs:focus {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .xl\:focus\:-translate-x-xs:focus {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .xl\:focus\:-translate-x-s:focus {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .xl\:focus\:-translate-x-m:focus {
+    --tw-translate-x: -1rem;
+  }
+
+  .xl\:focus\:-translate-x-l:focus {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .xl\:focus\:-translate-x-xl:focus {
+    --tw-translate-x: -2rem;
+  }
+
+  .xl\:focus\:-translate-x-xxl:focus {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .xl\:focus\:-translate-x-3xl:focus {
+    --tw-translate-x: -3rem;
+  }
+
+  .xl\:focus\:-translate-x-4xl:focus {
+    --tw-translate-x: -4rem;
+  }
+
+  .xl\:focus\:-translate-x-5xl:focus {
+    --tw-translate-x: -8rem;
   }
 
   .xl\:focus\:translate-x-1\/2:focus {
@@ -84426,6 +98253,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .xl\:focus\:translate-y-3xs:focus {
+    --tw-translate-y: .125rem;
+  }
+
+  .xl\:focus\:translate-y-xxs:focus {
+    --tw-translate-y: .25rem;
+  }
+
+  .xl\:focus\:translate-y-xs:focus {
+    --tw-translate-y: .5rem;
+  }
+
+  .xl\:focus\:translate-y-s:focus {
+    --tw-translate-y: .75rem;
+  }
+
+  .xl\:focus\:translate-y-m:focus {
+    --tw-translate-y: 1rem;
+  }
+
+  .xl\:focus\:translate-y-l:focus {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .xl\:focus\:translate-y-xl:focus {
+    --tw-translate-y: 2rem;
+  }
+
+  .xl\:focus\:translate-y-xxl:focus {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .xl\:focus\:translate-y-3xl:focus {
+    --tw-translate-y: 3rem;
+  }
+
+  .xl\:focus\:translate-y-4xl:focus {
+    --tw-translate-y: 4rem;
+  }
+
+  .xl\:focus\:translate-y-5xl:focus {
+    --tw-translate-y: 8rem;
+  }
+
   .xl\:focus\:-translate-y-0:focus {
     --tw-translate-y: 0px;
   }
@@ -84564,6 +98435,50 @@ video {
 
   .xl\:focus\:-translate-y-3\.5:focus {
     --tw-translate-y: -0.875rem;
+  }
+
+  .xl\:focus\:-translate-y-3xs:focus {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .xl\:focus\:-translate-y-xxs:focus {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .xl\:focus\:-translate-y-xs:focus {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .xl\:focus\:-translate-y-s:focus {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .xl\:focus\:-translate-y-m:focus {
+    --tw-translate-y: -1rem;
+  }
+
+  .xl\:focus\:-translate-y-l:focus {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .xl\:focus\:-translate-y-xl:focus {
+    --tw-translate-y: -2rem;
+  }
+
+  .xl\:focus\:-translate-y-xxl:focus {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .xl\:focus\:-translate-y-3xl:focus {
+    --tw-translate-y: -3rem;
+  }
+
+  .xl\:focus\:-translate-y-4xl:focus {
+    --tw-translate-y: -4rem;
+  }
+
+  .xl\:focus\:-translate-y-5xl:focus {
+    --tw-translate-y: -8rem;
   }
 
   .xl\:focus\:translate-y-1\/2:focus {
@@ -85487,6 +99402,138 @@ video {
     margin-left: calc(0.875rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
+  .\32xl\:space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.125rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.125rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.125rem * var(--tw-space-x-reverse));
+    margin-left: calc(.125rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.25rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.25rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:space-y-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.5rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:space-y-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(.75rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(.75rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:space-y-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1rem * var(--tw-space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:space-y-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:space-y-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2rem * var(--tw-space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(2.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(2.5rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(3rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(3rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(3rem * var(--tw-space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(4rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(4rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(4rem * var(--tw-space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(8rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(8rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(8rem * var(--tw-space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
   .\32xl\:-space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
@@ -85905,6 +99952,138 @@ video {
     --tw-space-x-reverse: 0;
     margin-right: calc(-0.875rem * var(--tw-space-x-reverse));
     margin-left: calc(-0.875rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.125rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.125rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-3xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.125rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.25rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.25rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-xxs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.5rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-xs > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-0.75rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-0.75rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-s > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-0.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-1rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-m > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-1rem * var(--tw-space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-1.5rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-l > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-2rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-2rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-2rem * var(--tw-space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-2.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-2.5rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-xxl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-3rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-3rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-3xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-3rem * var(--tw-space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-4rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-4rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-4xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-4rem * var(--tw-space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .\32xl\:-space-y-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(-8rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(-8rem * var(--tw-space-y-reverse));
+  }
+
+  .\32xl\:-space-x-5xl > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(-8rem * var(--tw-space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .\32xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -88563,6 +102742,50 @@ video {
     height: 0.875rem;
   }
 
+  .\32xl\:h-3xs {
+    height: .125rem;
+  }
+
+  .\32xl\:h-xxs {
+    height: .25rem;
+  }
+
+  .\32xl\:h-xs {
+    height: .5rem;
+  }
+
+  .\32xl\:h-s {
+    height: .75rem;
+  }
+
+  .\32xl\:h-m {
+    height: 1rem;
+  }
+
+  .\32xl\:h-l {
+    height: 1.5rem;
+  }
+
+  .\32xl\:h-xl {
+    height: 2rem;
+  }
+
+  .\32xl\:h-xxl {
+    height: 2.5rem;
+  }
+
+  .\32xl\:h-3xl {
+    height: 3rem;
+  }
+
+  .\32xl\:h-4xl {
+    height: 4rem;
+  }
+
+  .\32xl\:h-5xl {
+    height: 8rem;
+  }
+
   .\32xl\:h-1\/2 {
     height: 50%;
   }
@@ -88879,6 +103102,50 @@ video {
     margin: 0.875rem;
   }
 
+  .\32xl\:m-3xs {
+    margin: .125rem;
+  }
+
+  .\32xl\:m-xxs {
+    margin: .25rem;
+  }
+
+  .\32xl\:m-xs {
+    margin: .5rem;
+  }
+
+  .\32xl\:m-s {
+    margin: .75rem;
+  }
+
+  .\32xl\:m-m {
+    margin: 1rem;
+  }
+
+  .\32xl\:m-l {
+    margin: 1.5rem;
+  }
+
+  .\32xl\:m-xl {
+    margin: 2rem;
+  }
+
+  .\32xl\:m-xxl {
+    margin: 2.5rem;
+  }
+
+  .\32xl\:m-3xl {
+    margin: 3rem;
+  }
+
+  .\32xl\:m-4xl {
+    margin: 4rem;
+  }
+
+  .\32xl\:m-5xl {
+    margin: 8rem;
+  }
+
   .\32xl\:-m-0 {
     margin: 0px;
   }
@@ -89017,6 +103284,50 @@ video {
 
   .\32xl\:-m-3\.5 {
     margin: -0.875rem;
+  }
+
+  .\32xl\:-m-3xs {
+    margin: -0.125rem;
+  }
+
+  .\32xl\:-m-xxs {
+    margin: -0.25rem;
+  }
+
+  .\32xl\:-m-xs {
+    margin: -0.5rem;
+  }
+
+  .\32xl\:-m-s {
+    margin: -0.75rem;
+  }
+
+  .\32xl\:-m-m {
+    margin: -1rem;
+  }
+
+  .\32xl\:-m-l {
+    margin: -1.5rem;
+  }
+
+  .\32xl\:-m-xl {
+    margin: -2rem;
+  }
+
+  .\32xl\:-m-xxl {
+    margin: -2.5rem;
+  }
+
+  .\32xl\:-m-3xl {
+    margin: -3rem;
+  }
+
+  .\32xl\:-m-4xl {
+    margin: -4rem;
+  }
+
+  .\32xl\:-m-5xl {
+    margin: -8rem;
   }
 
   .\32xl\:my-0 {
@@ -89379,6 +103690,116 @@ video {
     margin-right: 0.875rem;
   }
 
+  .\32xl\:my-3xs {
+    margin-top: .125rem;
+    margin-bottom: .125rem;
+  }
+
+  .\32xl\:mx-3xs {
+    margin-left: .125rem;
+    margin-right: .125rem;
+  }
+
+  .\32xl\:my-xxs {
+    margin-top: .25rem;
+    margin-bottom: .25rem;
+  }
+
+  .\32xl\:mx-xxs {
+    margin-left: .25rem;
+    margin-right: .25rem;
+  }
+
+  .\32xl\:my-xs {
+    margin-top: .5rem;
+    margin-bottom: .5rem;
+  }
+
+  .\32xl\:mx-xs {
+    margin-left: .5rem;
+    margin-right: .5rem;
+  }
+
+  .\32xl\:my-s {
+    margin-top: .75rem;
+    margin-bottom: .75rem;
+  }
+
+  .\32xl\:mx-s {
+    margin-left: .75rem;
+    margin-right: .75rem;
+  }
+
+  .\32xl\:my-m {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .\32xl\:mx-m {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+
+  .\32xl\:my-l {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .\32xl\:mx-l {
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+
+  .\32xl\:my-xl {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .\32xl\:mx-xl {
+    margin-left: 2rem;
+    margin-right: 2rem;
+  }
+
+  .\32xl\:my-xxl {
+    margin-top: 2.5rem;
+    margin-bottom: 2.5rem;
+  }
+
+  .\32xl\:mx-xxl {
+    margin-left: 2.5rem;
+    margin-right: 2.5rem;
+  }
+
+  .\32xl\:my-3xl {
+    margin-top: 3rem;
+    margin-bottom: 3rem;
+  }
+
+  .\32xl\:mx-3xl {
+    margin-left: 3rem;
+    margin-right: 3rem;
+  }
+
+  .\32xl\:my-4xl {
+    margin-top: 4rem;
+    margin-bottom: 4rem;
+  }
+
+  .\32xl\:mx-4xl {
+    margin-left: 4rem;
+    margin-right: 4rem;
+  }
+
+  .\32xl\:my-5xl {
+    margin-top: 8rem;
+    margin-bottom: 8rem;
+  }
+
+  .\32xl\:mx-5xl {
+    margin-left: 8rem;
+    margin-right: 8rem;
+  }
+
   .\32xl\:-my-0 {
     margin-top: 0px;
     margin-bottom: 0px;
@@ -89727,6 +104148,116 @@ video {
   .\32xl\:-mx-3\.5 {
     margin-left: -0.875rem;
     margin-right: -0.875rem;
+  }
+
+  .\32xl\:-my-3xs {
+    margin-top: -0.125rem;
+    margin-bottom: -0.125rem;
+  }
+
+  .\32xl\:-mx-3xs {
+    margin-left: -0.125rem;
+    margin-right: -0.125rem;
+  }
+
+  .\32xl\:-my-xxs {
+    margin-top: -0.25rem;
+    margin-bottom: -0.25rem;
+  }
+
+  .\32xl\:-mx-xxs {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+  }
+
+  .\32xl\:-my-xs {
+    margin-top: -0.5rem;
+    margin-bottom: -0.5rem;
+  }
+
+  .\32xl\:-mx-xs {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+  }
+
+  .\32xl\:-my-s {
+    margin-top: -0.75rem;
+    margin-bottom: -0.75rem;
+  }
+
+  .\32xl\:-mx-s {
+    margin-left: -0.75rem;
+    margin-right: -0.75rem;
+  }
+
+  .\32xl\:-my-m {
+    margin-top: -1rem;
+    margin-bottom: -1rem;
+  }
+
+  .\32xl\:-mx-m {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+
+  .\32xl\:-my-l {
+    margin-top: -1.5rem;
+    margin-bottom: -1.5rem;
+  }
+
+  .\32xl\:-mx-l {
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+  }
+
+  .\32xl\:-my-xl {
+    margin-top: -2rem;
+    margin-bottom: -2rem;
+  }
+
+  .\32xl\:-mx-xl {
+    margin-left: -2rem;
+    margin-right: -2rem;
+  }
+
+  .\32xl\:-my-xxl {
+    margin-top: -2.5rem;
+    margin-bottom: -2.5rem;
+  }
+
+  .\32xl\:-mx-xxl {
+    margin-left: -2.5rem;
+    margin-right: -2.5rem;
+  }
+
+  .\32xl\:-my-3xl {
+    margin-top: -3rem;
+    margin-bottom: -3rem;
+  }
+
+  .\32xl\:-mx-3xl {
+    margin-left: -3rem;
+    margin-right: -3rem;
+  }
+
+  .\32xl\:-my-4xl {
+    margin-top: -4rem;
+    margin-bottom: -4rem;
+  }
+
+  .\32xl\:-mx-4xl {
+    margin-left: -4rem;
+    margin-right: -4rem;
+  }
+
+  .\32xl\:-my-5xl {
+    margin-top: -8rem;
+    margin-bottom: -8rem;
+  }
+
+  .\32xl\:-mx-5xl {
+    margin-left: -8rem;
+    margin-right: -8rem;
   }
 
   .\32xl\:mt-0 {
@@ -90305,6 +104836,182 @@ video {
     margin-left: 0.875rem;
   }
 
+  .\32xl\:mt-3xs {
+    margin-top: .125rem;
+  }
+
+  .\32xl\:mr-3xs {
+    margin-right: .125rem;
+  }
+
+  .\32xl\:mb-3xs {
+    margin-bottom: .125rem;
+  }
+
+  .\32xl\:ml-3xs {
+    margin-left: .125rem;
+  }
+
+  .\32xl\:mt-xxs {
+    margin-top: .25rem;
+  }
+
+  .\32xl\:mr-xxs {
+    margin-right: .25rem;
+  }
+
+  .\32xl\:mb-xxs {
+    margin-bottom: .25rem;
+  }
+
+  .\32xl\:ml-xxs {
+    margin-left: .25rem;
+  }
+
+  .\32xl\:mt-xs {
+    margin-top: .5rem;
+  }
+
+  .\32xl\:mr-xs {
+    margin-right: .5rem;
+  }
+
+  .\32xl\:mb-xs {
+    margin-bottom: .5rem;
+  }
+
+  .\32xl\:ml-xs {
+    margin-left: .5rem;
+  }
+
+  .\32xl\:mt-s {
+    margin-top: .75rem;
+  }
+
+  .\32xl\:mr-s {
+    margin-right: .75rem;
+  }
+
+  .\32xl\:mb-s {
+    margin-bottom: .75rem;
+  }
+
+  .\32xl\:ml-s {
+    margin-left: .75rem;
+  }
+
+  .\32xl\:mt-m {
+    margin-top: 1rem;
+  }
+
+  .\32xl\:mr-m {
+    margin-right: 1rem;
+  }
+
+  .\32xl\:mb-m {
+    margin-bottom: 1rem;
+  }
+
+  .\32xl\:ml-m {
+    margin-left: 1rem;
+  }
+
+  .\32xl\:mt-l {
+    margin-top: 1.5rem;
+  }
+
+  .\32xl\:mr-l {
+    margin-right: 1.5rem;
+  }
+
+  .\32xl\:mb-l {
+    margin-bottom: 1.5rem;
+  }
+
+  .\32xl\:ml-l {
+    margin-left: 1.5rem;
+  }
+
+  .\32xl\:mt-xl {
+    margin-top: 2rem;
+  }
+
+  .\32xl\:mr-xl {
+    margin-right: 2rem;
+  }
+
+  .\32xl\:mb-xl {
+    margin-bottom: 2rem;
+  }
+
+  .\32xl\:ml-xl {
+    margin-left: 2rem;
+  }
+
+  .\32xl\:mt-xxl {
+    margin-top: 2.5rem;
+  }
+
+  .\32xl\:mr-xxl {
+    margin-right: 2.5rem;
+  }
+
+  .\32xl\:mb-xxl {
+    margin-bottom: 2.5rem;
+  }
+
+  .\32xl\:ml-xxl {
+    margin-left: 2.5rem;
+  }
+
+  .\32xl\:mt-3xl {
+    margin-top: 3rem;
+  }
+
+  .\32xl\:mr-3xl {
+    margin-right: 3rem;
+  }
+
+  .\32xl\:mb-3xl {
+    margin-bottom: 3rem;
+  }
+
+  .\32xl\:ml-3xl {
+    margin-left: 3rem;
+  }
+
+  .\32xl\:mt-4xl {
+    margin-top: 4rem;
+  }
+
+  .\32xl\:mr-4xl {
+    margin-right: 4rem;
+  }
+
+  .\32xl\:mb-4xl {
+    margin-bottom: 4rem;
+  }
+
+  .\32xl\:ml-4xl {
+    margin-left: 4rem;
+  }
+
+  .\32xl\:mt-5xl {
+    margin-top: 8rem;
+  }
+
+  .\32xl\:mr-5xl {
+    margin-right: 8rem;
+  }
+
+  .\32xl\:mb-5xl {
+    margin-bottom: 8rem;
+  }
+
+  .\32xl\:ml-5xl {
+    margin-left: 8rem;
+  }
+
   .\32xl\:-mt-0 {
     margin-top: 0px;
   }
@@ -90865,6 +105572,182 @@ video {
     margin-left: -0.875rem;
   }
 
+  .\32xl\:-mt-3xs {
+    margin-top: -0.125rem;
+  }
+
+  .\32xl\:-mr-3xs {
+    margin-right: -0.125rem;
+  }
+
+  .\32xl\:-mb-3xs {
+    margin-bottom: -0.125rem;
+  }
+
+  .\32xl\:-ml-3xs {
+    margin-left: -0.125rem;
+  }
+
+  .\32xl\:-mt-xxs {
+    margin-top: -0.25rem;
+  }
+
+  .\32xl\:-mr-xxs {
+    margin-right: -0.25rem;
+  }
+
+  .\32xl\:-mb-xxs {
+    margin-bottom: -0.25rem;
+  }
+
+  .\32xl\:-ml-xxs {
+    margin-left: -0.25rem;
+  }
+
+  .\32xl\:-mt-xs {
+    margin-top: -0.5rem;
+  }
+
+  .\32xl\:-mr-xs {
+    margin-right: -0.5rem;
+  }
+
+  .\32xl\:-mb-xs {
+    margin-bottom: -0.5rem;
+  }
+
+  .\32xl\:-ml-xs {
+    margin-left: -0.5rem;
+  }
+
+  .\32xl\:-mt-s {
+    margin-top: -0.75rem;
+  }
+
+  .\32xl\:-mr-s {
+    margin-right: -0.75rem;
+  }
+
+  .\32xl\:-mb-s {
+    margin-bottom: -0.75rem;
+  }
+
+  .\32xl\:-ml-s {
+    margin-left: -0.75rem;
+  }
+
+  .\32xl\:-mt-m {
+    margin-top: -1rem;
+  }
+
+  .\32xl\:-mr-m {
+    margin-right: -1rem;
+  }
+
+  .\32xl\:-mb-m {
+    margin-bottom: -1rem;
+  }
+
+  .\32xl\:-ml-m {
+    margin-left: -1rem;
+  }
+
+  .\32xl\:-mt-l {
+    margin-top: -1.5rem;
+  }
+
+  .\32xl\:-mr-l {
+    margin-right: -1.5rem;
+  }
+
+  .\32xl\:-mb-l {
+    margin-bottom: -1.5rem;
+  }
+
+  .\32xl\:-ml-l {
+    margin-left: -1.5rem;
+  }
+
+  .\32xl\:-mt-xl {
+    margin-top: -2rem;
+  }
+
+  .\32xl\:-mr-xl {
+    margin-right: -2rem;
+  }
+
+  .\32xl\:-mb-xl {
+    margin-bottom: -2rem;
+  }
+
+  .\32xl\:-ml-xl {
+    margin-left: -2rem;
+  }
+
+  .\32xl\:-mt-xxl {
+    margin-top: -2.5rem;
+  }
+
+  .\32xl\:-mr-xxl {
+    margin-right: -2.5rem;
+  }
+
+  .\32xl\:-mb-xxl {
+    margin-bottom: -2.5rem;
+  }
+
+  .\32xl\:-ml-xxl {
+    margin-left: -2.5rem;
+  }
+
+  .\32xl\:-mt-3xl {
+    margin-top: -3rem;
+  }
+
+  .\32xl\:-mr-3xl {
+    margin-right: -3rem;
+  }
+
+  .\32xl\:-mb-3xl {
+    margin-bottom: -3rem;
+  }
+
+  .\32xl\:-ml-3xl {
+    margin-left: -3rem;
+  }
+
+  .\32xl\:-mt-4xl {
+    margin-top: -4rem;
+  }
+
+  .\32xl\:-mr-4xl {
+    margin-right: -4rem;
+  }
+
+  .\32xl\:-mb-4xl {
+    margin-bottom: -4rem;
+  }
+
+  .\32xl\:-ml-4xl {
+    margin-left: -4rem;
+  }
+
+  .\32xl\:-mt-5xl {
+    margin-top: -8rem;
+  }
+
+  .\32xl\:-mr-5xl {
+    margin-right: -8rem;
+  }
+
+  .\32xl\:-mb-5xl {
+    margin-bottom: -8rem;
+  }
+
+  .\32xl\:-ml-5xl {
+    margin-left: -8rem;
+  }
+
   .\32xl\:max-h-0 {
     max-height: 0px;
   }
@@ -91003,6 +105886,50 @@ video {
 
   .\32xl\:max-h-3\.5 {
     max-height: 0.875rem;
+  }
+
+  .\32xl\:max-h-3xs {
+    max-height: .125rem;
+  }
+
+  .\32xl\:max-h-xxs {
+    max-height: .25rem;
+  }
+
+  .\32xl\:max-h-xs {
+    max-height: .5rem;
+  }
+
+  .\32xl\:max-h-s {
+    max-height: .75rem;
+  }
+
+  .\32xl\:max-h-m {
+    max-height: 1rem;
+  }
+
+  .\32xl\:max-h-l {
+    max-height: 1.5rem;
+  }
+
+  .\32xl\:max-h-xl {
+    max-height: 2rem;
+  }
+
+  .\32xl\:max-h-xxl {
+    max-height: 2.5rem;
+  }
+
+  .\32xl\:max-h-3xl {
+    max-height: 3rem;
+  }
+
+  .\32xl\:max-h-4xl {
+    max-height: 4rem;
+  }
+
+  .\32xl\:max-h-5xl {
+    max-height: 8rem;
   }
 
   .\32xl\:max-h-full {
@@ -91779,6 +106706,50 @@ video {
     padding: 0.875rem;
   }
 
+  .\32xl\:p-3xs {
+    padding: .125rem;
+  }
+
+  .\32xl\:p-xxs {
+    padding: .25rem;
+  }
+
+  .\32xl\:p-xs {
+    padding: .5rem;
+  }
+
+  .\32xl\:p-s {
+    padding: .75rem;
+  }
+
+  .\32xl\:p-m {
+    padding: 1rem;
+  }
+
+  .\32xl\:p-l {
+    padding: 1.5rem;
+  }
+
+  .\32xl\:p-xl {
+    padding: 2rem;
+  }
+
+  .\32xl\:p-xxl {
+    padding: 2.5rem;
+  }
+
+  .\32xl\:p-3xl {
+    padding: 3rem;
+  }
+
+  .\32xl\:p-4xl {
+    padding: 4rem;
+  }
+
+  .\32xl\:p-5xl {
+    padding: 8rem;
+  }
+
   .\32xl\:py-0 {
     padding-top: 0px;
     padding-bottom: 0px;
@@ -92127,6 +107098,116 @@ video {
   .\32xl\:px-3\.5 {
     padding-left: 0.875rem;
     padding-right: 0.875rem;
+  }
+
+  .\32xl\:py-3xs {
+    padding-top: .125rem;
+    padding-bottom: .125rem;
+  }
+
+  .\32xl\:px-3xs {
+    padding-left: .125rem;
+    padding-right: .125rem;
+  }
+
+  .\32xl\:py-xxs {
+    padding-top: .25rem;
+    padding-bottom: .25rem;
+  }
+
+  .\32xl\:px-xxs {
+    padding-left: .25rem;
+    padding-right: .25rem;
+  }
+
+  .\32xl\:py-xs {
+    padding-top: .5rem;
+    padding-bottom: .5rem;
+  }
+
+  .\32xl\:px-xs {
+    padding-left: .5rem;
+    padding-right: .5rem;
+  }
+
+  .\32xl\:py-s {
+    padding-top: .75rem;
+    padding-bottom: .75rem;
+  }
+
+  .\32xl\:px-s {
+    padding-left: .75rem;
+    padding-right: .75rem;
+  }
+
+  .\32xl\:py-m {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .\32xl\:px-m {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .\32xl\:py-l {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .\32xl\:px-l {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .\32xl\:py-xl {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+
+  .\32xl\:px-xl {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
+  .\32xl\:py-xxl {
+    padding-top: 2.5rem;
+    padding-bottom: 2.5rem;
+  }
+
+  .\32xl\:px-xxl {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+  }
+
+  .\32xl\:py-3xl {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+
+  .\32xl\:px-3xl {
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
+
+  .\32xl\:py-4xl {
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+  }
+
+  .\32xl\:px-4xl {
+    padding-left: 4rem;
+    padding-right: 4rem;
+  }
+
+  .\32xl\:py-5xl {
+    padding-top: 8rem;
+    padding-bottom: 8rem;
+  }
+
+  .\32xl\:px-5xl {
+    padding-left: 8rem;
+    padding-right: 8rem;
   }
 
   .\32xl\:pt-0 {
@@ -92687,6 +107768,182 @@ video {
 
   .\32xl\:pl-3\.5 {
     padding-left: 0.875rem;
+  }
+
+  .\32xl\:pt-3xs {
+    padding-top: .125rem;
+  }
+
+  .\32xl\:pr-3xs {
+    padding-right: .125rem;
+  }
+
+  .\32xl\:pb-3xs {
+    padding-bottom: .125rem;
+  }
+
+  .\32xl\:pl-3xs {
+    padding-left: .125rem;
+  }
+
+  .\32xl\:pt-xxs {
+    padding-top: .25rem;
+  }
+
+  .\32xl\:pr-xxs {
+    padding-right: .25rem;
+  }
+
+  .\32xl\:pb-xxs {
+    padding-bottom: .25rem;
+  }
+
+  .\32xl\:pl-xxs {
+    padding-left: .25rem;
+  }
+
+  .\32xl\:pt-xs {
+    padding-top: .5rem;
+  }
+
+  .\32xl\:pr-xs {
+    padding-right: .5rem;
+  }
+
+  .\32xl\:pb-xs {
+    padding-bottom: .5rem;
+  }
+
+  .\32xl\:pl-xs {
+    padding-left: .5rem;
+  }
+
+  .\32xl\:pt-s {
+    padding-top: .75rem;
+  }
+
+  .\32xl\:pr-s {
+    padding-right: .75rem;
+  }
+
+  .\32xl\:pb-s {
+    padding-bottom: .75rem;
+  }
+
+  .\32xl\:pl-s {
+    padding-left: .75rem;
+  }
+
+  .\32xl\:pt-m {
+    padding-top: 1rem;
+  }
+
+  .\32xl\:pr-m {
+    padding-right: 1rem;
+  }
+
+  .\32xl\:pb-m {
+    padding-bottom: 1rem;
+  }
+
+  .\32xl\:pl-m {
+    padding-left: 1rem;
+  }
+
+  .\32xl\:pt-l {
+    padding-top: 1.5rem;
+  }
+
+  .\32xl\:pr-l {
+    padding-right: 1.5rem;
+  }
+
+  .\32xl\:pb-l {
+    padding-bottom: 1.5rem;
+  }
+
+  .\32xl\:pl-l {
+    padding-left: 1.5rem;
+  }
+
+  .\32xl\:pt-xl {
+    padding-top: 2rem;
+  }
+
+  .\32xl\:pr-xl {
+    padding-right: 2rem;
+  }
+
+  .\32xl\:pb-xl {
+    padding-bottom: 2rem;
+  }
+
+  .\32xl\:pl-xl {
+    padding-left: 2rem;
+  }
+
+  .\32xl\:pt-xxl {
+    padding-top: 2.5rem;
+  }
+
+  .\32xl\:pr-xxl {
+    padding-right: 2.5rem;
+  }
+
+  .\32xl\:pb-xxl {
+    padding-bottom: 2.5rem;
+  }
+
+  .\32xl\:pl-xxl {
+    padding-left: 2.5rem;
+  }
+
+  .\32xl\:pt-3xl {
+    padding-top: 3rem;
+  }
+
+  .\32xl\:pr-3xl {
+    padding-right: 3rem;
+  }
+
+  .\32xl\:pb-3xl {
+    padding-bottom: 3rem;
+  }
+
+  .\32xl\:pl-3xl {
+    padding-left: 3rem;
+  }
+
+  .\32xl\:pt-4xl {
+    padding-top: 4rem;
+  }
+
+  .\32xl\:pr-4xl {
+    padding-right: 4rem;
+  }
+
+  .\32xl\:pb-4xl {
+    padding-bottom: 4rem;
+  }
+
+  .\32xl\:pl-4xl {
+    padding-left: 4rem;
+  }
+
+  .\32xl\:pt-5xl {
+    padding-top: 8rem;
+  }
+
+  .\32xl\:pr-5xl {
+    padding-right: 8rem;
+  }
+
+  .\32xl\:pb-5xl {
+    padding-bottom: 8rem;
+  }
+
+  .\32xl\:pl-5xl {
+    padding-left: 8rem;
   }
 
   .\32xl\:placeholder-primary::-moz-placeholder {
@@ -93570,6 +108827,83 @@ video {
     left: 0.875rem;
   }
 
+  .\32xl\:inset-3xs {
+    top: .125rem;
+    right: .125rem;
+    bottom: .125rem;
+    left: .125rem;
+  }
+
+  .\32xl\:inset-xxs {
+    top: .25rem;
+    right: .25rem;
+    bottom: .25rem;
+    left: .25rem;
+  }
+
+  .\32xl\:inset-xs {
+    top: .5rem;
+    right: .5rem;
+    bottom: .5rem;
+    left: .5rem;
+  }
+
+  .\32xl\:inset-s {
+    top: .75rem;
+    right: .75rem;
+    bottom: .75rem;
+    left: .75rem;
+  }
+
+  .\32xl\:inset-m {
+    top: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    left: 1rem;
+  }
+
+  .\32xl\:inset-l {
+    top: 1.5rem;
+    right: 1.5rem;
+    bottom: 1.5rem;
+    left: 1.5rem;
+  }
+
+  .\32xl\:inset-xl {
+    top: 2rem;
+    right: 2rem;
+    bottom: 2rem;
+    left: 2rem;
+  }
+
+  .\32xl\:inset-xxl {
+    top: 2.5rem;
+    right: 2.5rem;
+    bottom: 2.5rem;
+    left: 2.5rem;
+  }
+
+  .\32xl\:inset-3xl {
+    top: 3rem;
+    right: 3rem;
+    bottom: 3rem;
+    left: 3rem;
+  }
+
+  .\32xl\:inset-4xl {
+    top: 4rem;
+    right: 4rem;
+    bottom: 4rem;
+    left: 4rem;
+  }
+
+  .\32xl\:inset-5xl {
+    top: 8rem;
+    right: 8rem;
+    bottom: 8rem;
+    left: 8rem;
+  }
+
   .\32xl\:-inset-0 {
     top: 0px;
     right: 0px;
@@ -93813,6 +109147,83 @@ video {
     right: -0.875rem;
     bottom: -0.875rem;
     left: -0.875rem;
+  }
+
+  .\32xl\:-inset-3xs {
+    top: -0.125rem;
+    right: -0.125rem;
+    bottom: -0.125rem;
+    left: -0.125rem;
+  }
+
+  .\32xl\:-inset-xxs {
+    top: -0.25rem;
+    right: -0.25rem;
+    bottom: -0.25rem;
+    left: -0.25rem;
+  }
+
+  .\32xl\:-inset-xs {
+    top: -0.5rem;
+    right: -0.5rem;
+    bottom: -0.5rem;
+    left: -0.5rem;
+  }
+
+  .\32xl\:-inset-s {
+    top: -0.75rem;
+    right: -0.75rem;
+    bottom: -0.75rem;
+    left: -0.75rem;
+  }
+
+  .\32xl\:-inset-m {
+    top: -1rem;
+    right: -1rem;
+    bottom: -1rem;
+    left: -1rem;
+  }
+
+  .\32xl\:-inset-l {
+    top: -1.5rem;
+    right: -1.5rem;
+    bottom: -1.5rem;
+    left: -1.5rem;
+  }
+
+  .\32xl\:-inset-xl {
+    top: -2rem;
+    right: -2rem;
+    bottom: -2rem;
+    left: -2rem;
+  }
+
+  .\32xl\:-inset-xxl {
+    top: -2.5rem;
+    right: -2.5rem;
+    bottom: -2.5rem;
+    left: -2.5rem;
+  }
+
+  .\32xl\:-inset-3xl {
+    top: -3rem;
+    right: -3rem;
+    bottom: -3rem;
+    left: -3rem;
+  }
+
+  .\32xl\:-inset-4xl {
+    top: -4rem;
+    right: -4rem;
+    bottom: -4rem;
+    left: -4rem;
+  }
+
+  .\32xl\:-inset-5xl {
+    top: -8rem;
+    right: -8rem;
+    bottom: -8rem;
+    left: -8rem;
   }
 
   .\32xl\:inset-1\/2 {
@@ -94273,6 +109684,116 @@ video {
     left: 0.875rem;
   }
 
+  .\32xl\:inset-y-3xs {
+    top: .125rem;
+    bottom: .125rem;
+  }
+
+  .\32xl\:inset-x-3xs {
+    right: .125rem;
+    left: .125rem;
+  }
+
+  .\32xl\:inset-y-xxs {
+    top: .25rem;
+    bottom: .25rem;
+  }
+
+  .\32xl\:inset-x-xxs {
+    right: .25rem;
+    left: .25rem;
+  }
+
+  .\32xl\:inset-y-xs {
+    top: .5rem;
+    bottom: .5rem;
+  }
+
+  .\32xl\:inset-x-xs {
+    right: .5rem;
+    left: .5rem;
+  }
+
+  .\32xl\:inset-y-s {
+    top: .75rem;
+    bottom: .75rem;
+  }
+
+  .\32xl\:inset-x-s {
+    right: .75rem;
+    left: .75rem;
+  }
+
+  .\32xl\:inset-y-m {
+    top: 1rem;
+    bottom: 1rem;
+  }
+
+  .\32xl\:inset-x-m {
+    right: 1rem;
+    left: 1rem;
+  }
+
+  .\32xl\:inset-y-l {
+    top: 1.5rem;
+    bottom: 1.5rem;
+  }
+
+  .\32xl\:inset-x-l {
+    right: 1.5rem;
+    left: 1.5rem;
+  }
+
+  .\32xl\:inset-y-xl {
+    top: 2rem;
+    bottom: 2rem;
+  }
+
+  .\32xl\:inset-x-xl {
+    right: 2rem;
+    left: 2rem;
+  }
+
+  .\32xl\:inset-y-xxl {
+    top: 2.5rem;
+    bottom: 2.5rem;
+  }
+
+  .\32xl\:inset-x-xxl {
+    right: 2.5rem;
+    left: 2.5rem;
+  }
+
+  .\32xl\:inset-y-3xl {
+    top: 3rem;
+    bottom: 3rem;
+  }
+
+  .\32xl\:inset-x-3xl {
+    right: 3rem;
+    left: 3rem;
+  }
+
+  .\32xl\:inset-y-4xl {
+    top: 4rem;
+    bottom: 4rem;
+  }
+
+  .\32xl\:inset-x-4xl {
+    right: 4rem;
+    left: 4rem;
+  }
+
+  .\32xl\:inset-y-5xl {
+    top: 8rem;
+    bottom: 8rem;
+  }
+
+  .\32xl\:inset-x-5xl {
+    right: 8rem;
+    left: 8rem;
+  }
+
   .\32xl\:-inset-y-0 {
     top: 0px;
     bottom: 0px;
@@ -94621,6 +110142,116 @@ video {
   .\32xl\:-inset-x-3\.5 {
     right: -0.875rem;
     left: -0.875rem;
+  }
+
+  .\32xl\:-inset-y-3xs {
+    top: -0.125rem;
+    bottom: -0.125rem;
+  }
+
+  .\32xl\:-inset-x-3xs {
+    right: -0.125rem;
+    left: -0.125rem;
+  }
+
+  .\32xl\:-inset-y-xxs {
+    top: -0.25rem;
+    bottom: -0.25rem;
+  }
+
+  .\32xl\:-inset-x-xxs {
+    right: -0.25rem;
+    left: -0.25rem;
+  }
+
+  .\32xl\:-inset-y-xs {
+    top: -0.5rem;
+    bottom: -0.5rem;
+  }
+
+  .\32xl\:-inset-x-xs {
+    right: -0.5rem;
+    left: -0.5rem;
+  }
+
+  .\32xl\:-inset-y-s {
+    top: -0.75rem;
+    bottom: -0.75rem;
+  }
+
+  .\32xl\:-inset-x-s {
+    right: -0.75rem;
+    left: -0.75rem;
+  }
+
+  .\32xl\:-inset-y-m {
+    top: -1rem;
+    bottom: -1rem;
+  }
+
+  .\32xl\:-inset-x-m {
+    right: -1rem;
+    left: -1rem;
+  }
+
+  .\32xl\:-inset-y-l {
+    top: -1.5rem;
+    bottom: -1.5rem;
+  }
+
+  .\32xl\:-inset-x-l {
+    right: -1.5rem;
+    left: -1.5rem;
+  }
+
+  .\32xl\:-inset-y-xl {
+    top: -2rem;
+    bottom: -2rem;
+  }
+
+  .\32xl\:-inset-x-xl {
+    right: -2rem;
+    left: -2rem;
+  }
+
+  .\32xl\:-inset-y-xxl {
+    top: -2.5rem;
+    bottom: -2.5rem;
+  }
+
+  .\32xl\:-inset-x-xxl {
+    right: -2.5rem;
+    left: -2.5rem;
+  }
+
+  .\32xl\:-inset-y-3xl {
+    top: -3rem;
+    bottom: -3rem;
+  }
+
+  .\32xl\:-inset-x-3xl {
+    right: -3rem;
+    left: -3rem;
+  }
+
+  .\32xl\:-inset-y-4xl {
+    top: -4rem;
+    bottom: -4rem;
+  }
+
+  .\32xl\:-inset-x-4xl {
+    right: -4rem;
+    left: -4rem;
+  }
+
+  .\32xl\:-inset-y-5xl {
+    top: -8rem;
+    bottom: -8rem;
+  }
+
+  .\32xl\:-inset-x-5xl {
+    right: -8rem;
+    left: -8rem;
   }
 
   .\32xl\:inset-y-1\/2 {
@@ -95339,6 +110970,182 @@ video {
     left: 0.875rem;
   }
 
+  .\32xl\:top-3xs {
+    top: .125rem;
+  }
+
+  .\32xl\:right-3xs {
+    right: .125rem;
+  }
+
+  .\32xl\:bottom-3xs {
+    bottom: .125rem;
+  }
+
+  .\32xl\:left-3xs {
+    left: .125rem;
+  }
+
+  .\32xl\:top-xxs {
+    top: .25rem;
+  }
+
+  .\32xl\:right-xxs {
+    right: .25rem;
+  }
+
+  .\32xl\:bottom-xxs {
+    bottom: .25rem;
+  }
+
+  .\32xl\:left-xxs {
+    left: .25rem;
+  }
+
+  .\32xl\:top-xs {
+    top: .5rem;
+  }
+
+  .\32xl\:right-xs {
+    right: .5rem;
+  }
+
+  .\32xl\:bottom-xs {
+    bottom: .5rem;
+  }
+
+  .\32xl\:left-xs {
+    left: .5rem;
+  }
+
+  .\32xl\:top-s {
+    top: .75rem;
+  }
+
+  .\32xl\:right-s {
+    right: .75rem;
+  }
+
+  .\32xl\:bottom-s {
+    bottom: .75rem;
+  }
+
+  .\32xl\:left-s {
+    left: .75rem;
+  }
+
+  .\32xl\:top-m {
+    top: 1rem;
+  }
+
+  .\32xl\:right-m {
+    right: 1rem;
+  }
+
+  .\32xl\:bottom-m {
+    bottom: 1rem;
+  }
+
+  .\32xl\:left-m {
+    left: 1rem;
+  }
+
+  .\32xl\:top-l {
+    top: 1.5rem;
+  }
+
+  .\32xl\:right-l {
+    right: 1.5rem;
+  }
+
+  .\32xl\:bottom-l {
+    bottom: 1.5rem;
+  }
+
+  .\32xl\:left-l {
+    left: 1.5rem;
+  }
+
+  .\32xl\:top-xl {
+    top: 2rem;
+  }
+
+  .\32xl\:right-xl {
+    right: 2rem;
+  }
+
+  .\32xl\:bottom-xl {
+    bottom: 2rem;
+  }
+
+  .\32xl\:left-xl {
+    left: 2rem;
+  }
+
+  .\32xl\:top-xxl {
+    top: 2.5rem;
+  }
+
+  .\32xl\:right-xxl {
+    right: 2.5rem;
+  }
+
+  .\32xl\:bottom-xxl {
+    bottom: 2.5rem;
+  }
+
+  .\32xl\:left-xxl {
+    left: 2.5rem;
+  }
+
+  .\32xl\:top-3xl {
+    top: 3rem;
+  }
+
+  .\32xl\:right-3xl {
+    right: 3rem;
+  }
+
+  .\32xl\:bottom-3xl {
+    bottom: 3rem;
+  }
+
+  .\32xl\:left-3xl {
+    left: 3rem;
+  }
+
+  .\32xl\:top-4xl {
+    top: 4rem;
+  }
+
+  .\32xl\:right-4xl {
+    right: 4rem;
+  }
+
+  .\32xl\:bottom-4xl {
+    bottom: 4rem;
+  }
+
+  .\32xl\:left-4xl {
+    left: 4rem;
+  }
+
+  .\32xl\:top-5xl {
+    top: 8rem;
+  }
+
+  .\32xl\:right-5xl {
+    right: 8rem;
+  }
+
+  .\32xl\:bottom-5xl {
+    bottom: 8rem;
+  }
+
+  .\32xl\:left-5xl {
+    left: 8rem;
+  }
+
   .\32xl\:-top-0 {
     top: 0px;
   }
@@ -95897,6 +111704,182 @@ video {
 
   .\32xl\:-left-3\.5 {
     left: -0.875rem;
+  }
+
+  .\32xl\:-top-3xs {
+    top: -0.125rem;
+  }
+
+  .\32xl\:-right-3xs {
+    right: -0.125rem;
+  }
+
+  .\32xl\:-bottom-3xs {
+    bottom: -0.125rem;
+  }
+
+  .\32xl\:-left-3xs {
+    left: -0.125rem;
+  }
+
+  .\32xl\:-top-xxs {
+    top: -0.25rem;
+  }
+
+  .\32xl\:-right-xxs {
+    right: -0.25rem;
+  }
+
+  .\32xl\:-bottom-xxs {
+    bottom: -0.25rem;
+  }
+
+  .\32xl\:-left-xxs {
+    left: -0.25rem;
+  }
+
+  .\32xl\:-top-xs {
+    top: -0.5rem;
+  }
+
+  .\32xl\:-right-xs {
+    right: -0.5rem;
+  }
+
+  .\32xl\:-bottom-xs {
+    bottom: -0.5rem;
+  }
+
+  .\32xl\:-left-xs {
+    left: -0.5rem;
+  }
+
+  .\32xl\:-top-s {
+    top: -0.75rem;
+  }
+
+  .\32xl\:-right-s {
+    right: -0.75rem;
+  }
+
+  .\32xl\:-bottom-s {
+    bottom: -0.75rem;
+  }
+
+  .\32xl\:-left-s {
+    left: -0.75rem;
+  }
+
+  .\32xl\:-top-m {
+    top: -1rem;
+  }
+
+  .\32xl\:-right-m {
+    right: -1rem;
+  }
+
+  .\32xl\:-bottom-m {
+    bottom: -1rem;
+  }
+
+  .\32xl\:-left-m {
+    left: -1rem;
+  }
+
+  .\32xl\:-top-l {
+    top: -1.5rem;
+  }
+
+  .\32xl\:-right-l {
+    right: -1.5rem;
+  }
+
+  .\32xl\:-bottom-l {
+    bottom: -1.5rem;
+  }
+
+  .\32xl\:-left-l {
+    left: -1.5rem;
+  }
+
+  .\32xl\:-top-xl {
+    top: -2rem;
+  }
+
+  .\32xl\:-right-xl {
+    right: -2rem;
+  }
+
+  .\32xl\:-bottom-xl {
+    bottom: -2rem;
+  }
+
+  .\32xl\:-left-xl {
+    left: -2rem;
+  }
+
+  .\32xl\:-top-xxl {
+    top: -2.5rem;
+  }
+
+  .\32xl\:-right-xxl {
+    right: -2.5rem;
+  }
+
+  .\32xl\:-bottom-xxl {
+    bottom: -2.5rem;
+  }
+
+  .\32xl\:-left-xxl {
+    left: -2.5rem;
+  }
+
+  .\32xl\:-top-3xl {
+    top: -3rem;
+  }
+
+  .\32xl\:-right-3xl {
+    right: -3rem;
+  }
+
+  .\32xl\:-bottom-3xl {
+    bottom: -3rem;
+  }
+
+  .\32xl\:-left-3xl {
+    left: -3rem;
+  }
+
+  .\32xl\:-top-4xl {
+    top: -4rem;
+  }
+
+  .\32xl\:-right-4xl {
+    right: -4rem;
+  }
+
+  .\32xl\:-bottom-4xl {
+    bottom: -4rem;
+  }
+
+  .\32xl\:-left-4xl {
+    left: -4rem;
+  }
+
+  .\32xl\:-top-5xl {
+    top: -8rem;
+  }
+
+  .\32xl\:-right-5xl {
+    right: -8rem;
+  }
+
+  .\32xl\:-bottom-5xl {
+    bottom: -8rem;
+  }
+
+  .\32xl\:-left-5xl {
+    left: -8rem;
   }
 
   .\32xl\:top-1\/2 {
@@ -97772,6 +113755,50 @@ video {
     width: 0.875rem;
   }
 
+  .\32xl\:w-3xs {
+    width: .125rem;
+  }
+
+  .\32xl\:w-xxs {
+    width: .25rem;
+  }
+
+  .\32xl\:w-xs {
+    width: .5rem;
+  }
+
+  .\32xl\:w-s {
+    width: .75rem;
+  }
+
+  .\32xl\:w-m {
+    width: 1rem;
+  }
+
+  .\32xl\:w-l {
+    width: 1.5rem;
+  }
+
+  .\32xl\:w-xl {
+    width: 2rem;
+  }
+
+  .\32xl\:w-xxl {
+    width: 2.5rem;
+  }
+
+  .\32xl\:w-3xl {
+    width: 3rem;
+  }
+
+  .\32xl\:w-4xl {
+    width: 4rem;
+  }
+
+  .\32xl\:w-5xl {
+    width: 8rem;
+  }
+
   .\32xl\:w-1\/2 {
     width: 50%;
   }
@@ -98120,6 +114147,50 @@ video {
     gap: 0.875rem;
   }
 
+  .\32xl\:gap-3xs {
+    gap: .125rem;
+  }
+
+  .\32xl\:gap-xxs {
+    gap: .25rem;
+  }
+
+  .\32xl\:gap-xs {
+    gap: .5rem;
+  }
+
+  .\32xl\:gap-s {
+    gap: .75rem;
+  }
+
+  .\32xl\:gap-m {
+    gap: 1rem;
+  }
+
+  .\32xl\:gap-l {
+    gap: 1.5rem;
+  }
+
+  .\32xl\:gap-xl {
+    gap: 2rem;
+  }
+
+  .\32xl\:gap-xxl {
+    gap: 2.5rem;
+  }
+
+  .\32xl\:gap-3xl {
+    gap: 3rem;
+  }
+
+  .\32xl\:gap-4xl {
+    gap: 4rem;
+  }
+
+  .\32xl\:gap-5xl {
+    gap: 8rem;
+  }
+
   .\32xl\:gap-x-0 {
     -moz-column-gap: 0px;
          column-gap: 0px;
@@ -98295,6 +114366,61 @@ video {
          column-gap: 0.875rem;
   }
 
+  .\32xl\:gap-x-3xs {
+    -moz-column-gap: .125rem;
+         column-gap: .125rem;
+  }
+
+  .\32xl\:gap-x-xxs {
+    -moz-column-gap: .25rem;
+         column-gap: .25rem;
+  }
+
+  .\32xl\:gap-x-xs {
+    -moz-column-gap: .5rem;
+         column-gap: .5rem;
+  }
+
+  .\32xl\:gap-x-s {
+    -moz-column-gap: .75rem;
+         column-gap: .75rem;
+  }
+
+  .\32xl\:gap-x-m {
+    -moz-column-gap: 1rem;
+         column-gap: 1rem;
+  }
+
+  .\32xl\:gap-x-l {
+    -moz-column-gap: 1.5rem;
+         column-gap: 1.5rem;
+  }
+
+  .\32xl\:gap-x-xl {
+    -moz-column-gap: 2rem;
+         column-gap: 2rem;
+  }
+
+  .\32xl\:gap-x-xxl {
+    -moz-column-gap: 2.5rem;
+         column-gap: 2.5rem;
+  }
+
+  .\32xl\:gap-x-3xl {
+    -moz-column-gap: 3rem;
+         column-gap: 3rem;
+  }
+
+  .\32xl\:gap-x-4xl {
+    -moz-column-gap: 4rem;
+         column-gap: 4rem;
+  }
+
+  .\32xl\:gap-x-5xl {
+    -moz-column-gap: 8rem;
+         column-gap: 8rem;
+  }
+
   .\32xl\:gap-y-0 {
     row-gap: 0px;
   }
@@ -98433,6 +114559,50 @@ video {
 
   .\32xl\:gap-y-3\.5 {
     row-gap: 0.875rem;
+  }
+
+  .\32xl\:gap-y-3xs {
+    row-gap: .125rem;
+  }
+
+  .\32xl\:gap-y-xxs {
+    row-gap: .25rem;
+  }
+
+  .\32xl\:gap-y-xs {
+    row-gap: .5rem;
+  }
+
+  .\32xl\:gap-y-s {
+    row-gap: .75rem;
+  }
+
+  .\32xl\:gap-y-m {
+    row-gap: 1rem;
+  }
+
+  .\32xl\:gap-y-l {
+    row-gap: 1.5rem;
+  }
+
+  .\32xl\:gap-y-xl {
+    row-gap: 2rem;
+  }
+
+  .\32xl\:gap-y-xxl {
+    row-gap: 2.5rem;
+  }
+
+  .\32xl\:gap-y-3xl {
+    row-gap: 3rem;
+  }
+
+  .\32xl\:gap-y-4xl {
+    row-gap: 4rem;
+  }
+
+  .\32xl\:gap-y-5xl {
+    row-gap: 8rem;
   }
 
   .\32xl\:grid-flow-row {
@@ -99627,6 +115797,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .\32xl\:translate-x-3xs {
+    --tw-translate-x: .125rem;
+  }
+
+  .\32xl\:translate-x-xxs {
+    --tw-translate-x: .25rem;
+  }
+
+  .\32xl\:translate-x-xs {
+    --tw-translate-x: .5rem;
+  }
+
+  .\32xl\:translate-x-s {
+    --tw-translate-x: .75rem;
+  }
+
+  .\32xl\:translate-x-m {
+    --tw-translate-x: 1rem;
+  }
+
+  .\32xl\:translate-x-l {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .\32xl\:translate-x-xl {
+    --tw-translate-x: 2rem;
+  }
+
+  .\32xl\:translate-x-xxl {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .\32xl\:translate-x-3xl {
+    --tw-translate-x: 3rem;
+  }
+
+  .\32xl\:translate-x-4xl {
+    --tw-translate-x: 4rem;
+  }
+
+  .\32xl\:translate-x-5xl {
+    --tw-translate-x: 8rem;
+  }
+
   .\32xl\:-translate-x-0 {
     --tw-translate-x: 0px;
   }
@@ -99765,6 +115979,50 @@ video {
 
   .\32xl\:-translate-x-3\.5 {
     --tw-translate-x: -0.875rem;
+  }
+
+  .\32xl\:-translate-x-3xs {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .\32xl\:-translate-x-xxs {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .\32xl\:-translate-x-xs {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .\32xl\:-translate-x-s {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .\32xl\:-translate-x-m {
+    --tw-translate-x: -1rem;
+  }
+
+  .\32xl\:-translate-x-l {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .\32xl\:-translate-x-xl {
+    --tw-translate-x: -2rem;
+  }
+
+  .\32xl\:-translate-x-xxl {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .\32xl\:-translate-x-3xl {
+    --tw-translate-x: -3rem;
+  }
+
+  .\32xl\:-translate-x-4xl {
+    --tw-translate-x: -4rem;
+  }
+
+  .\32xl\:-translate-x-5xl {
+    --tw-translate-x: -8rem;
   }
 
   .\32xl\:translate-x-1\/2 {
@@ -99963,6 +116221,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .\32xl\:translate-y-3xs {
+    --tw-translate-y: .125rem;
+  }
+
+  .\32xl\:translate-y-xxs {
+    --tw-translate-y: .25rem;
+  }
+
+  .\32xl\:translate-y-xs {
+    --tw-translate-y: .5rem;
+  }
+
+  .\32xl\:translate-y-s {
+    --tw-translate-y: .75rem;
+  }
+
+  .\32xl\:translate-y-m {
+    --tw-translate-y: 1rem;
+  }
+
+  .\32xl\:translate-y-l {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .\32xl\:translate-y-xl {
+    --tw-translate-y: 2rem;
+  }
+
+  .\32xl\:translate-y-xxl {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .\32xl\:translate-y-3xl {
+    --tw-translate-y: 3rem;
+  }
+
+  .\32xl\:translate-y-4xl {
+    --tw-translate-y: 4rem;
+  }
+
+  .\32xl\:translate-y-5xl {
+    --tw-translate-y: 8rem;
+  }
+
   .\32xl\:-translate-y-0 {
     --tw-translate-y: 0px;
   }
@@ -100101,6 +116403,50 @@ video {
 
   .\32xl\:-translate-y-3\.5 {
     --tw-translate-y: -0.875rem;
+  }
+
+  .\32xl\:-translate-y-3xs {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .\32xl\:-translate-y-xxs {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .\32xl\:-translate-y-xs {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .\32xl\:-translate-y-s {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .\32xl\:-translate-y-m {
+    --tw-translate-y: -1rem;
+  }
+
+  .\32xl\:-translate-y-l {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .\32xl\:-translate-y-xl {
+    --tw-translate-y: -2rem;
+  }
+
+  .\32xl\:-translate-y-xxl {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .\32xl\:-translate-y-3xl {
+    --tw-translate-y: -3rem;
+  }
+
+  .\32xl\:-translate-y-4xl {
+    --tw-translate-y: -4rem;
+  }
+
+  .\32xl\:-translate-y-5xl {
+    --tw-translate-y: -8rem;
   }
 
   .\32xl\:translate-y-1\/2 {
@@ -100299,6 +116645,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .\32xl\:hover\:translate-x-3xs:hover {
+    --tw-translate-x: .125rem;
+  }
+
+  .\32xl\:hover\:translate-x-xxs:hover {
+    --tw-translate-x: .25rem;
+  }
+
+  .\32xl\:hover\:translate-x-xs:hover {
+    --tw-translate-x: .5rem;
+  }
+
+  .\32xl\:hover\:translate-x-s:hover {
+    --tw-translate-x: .75rem;
+  }
+
+  .\32xl\:hover\:translate-x-m:hover {
+    --tw-translate-x: 1rem;
+  }
+
+  .\32xl\:hover\:translate-x-l:hover {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .\32xl\:hover\:translate-x-xl:hover {
+    --tw-translate-x: 2rem;
+  }
+
+  .\32xl\:hover\:translate-x-xxl:hover {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .\32xl\:hover\:translate-x-3xl:hover {
+    --tw-translate-x: 3rem;
+  }
+
+  .\32xl\:hover\:translate-x-4xl:hover {
+    --tw-translate-x: 4rem;
+  }
+
+  .\32xl\:hover\:translate-x-5xl:hover {
+    --tw-translate-x: 8rem;
+  }
+
   .\32xl\:hover\:-translate-x-0:hover {
     --tw-translate-x: 0px;
   }
@@ -100437,6 +116827,50 @@ video {
 
   .\32xl\:hover\:-translate-x-3\.5:hover {
     --tw-translate-x: -0.875rem;
+  }
+
+  .\32xl\:hover\:-translate-x-3xs:hover {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .\32xl\:hover\:-translate-x-xxs:hover {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .\32xl\:hover\:-translate-x-xs:hover {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .\32xl\:hover\:-translate-x-s:hover {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .\32xl\:hover\:-translate-x-m:hover {
+    --tw-translate-x: -1rem;
+  }
+
+  .\32xl\:hover\:-translate-x-l:hover {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .\32xl\:hover\:-translate-x-xl:hover {
+    --tw-translate-x: -2rem;
+  }
+
+  .\32xl\:hover\:-translate-x-xxl:hover {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .\32xl\:hover\:-translate-x-3xl:hover {
+    --tw-translate-x: -3rem;
+  }
+
+  .\32xl\:hover\:-translate-x-4xl:hover {
+    --tw-translate-x: -4rem;
+  }
+
+  .\32xl\:hover\:-translate-x-5xl:hover {
+    --tw-translate-x: -8rem;
   }
 
   .\32xl\:hover\:translate-x-1\/2:hover {
@@ -100635,6 +117069,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .\32xl\:hover\:translate-y-3xs:hover {
+    --tw-translate-y: .125rem;
+  }
+
+  .\32xl\:hover\:translate-y-xxs:hover {
+    --tw-translate-y: .25rem;
+  }
+
+  .\32xl\:hover\:translate-y-xs:hover {
+    --tw-translate-y: .5rem;
+  }
+
+  .\32xl\:hover\:translate-y-s:hover {
+    --tw-translate-y: .75rem;
+  }
+
+  .\32xl\:hover\:translate-y-m:hover {
+    --tw-translate-y: 1rem;
+  }
+
+  .\32xl\:hover\:translate-y-l:hover {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .\32xl\:hover\:translate-y-xl:hover {
+    --tw-translate-y: 2rem;
+  }
+
+  .\32xl\:hover\:translate-y-xxl:hover {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .\32xl\:hover\:translate-y-3xl:hover {
+    --tw-translate-y: 3rem;
+  }
+
+  .\32xl\:hover\:translate-y-4xl:hover {
+    --tw-translate-y: 4rem;
+  }
+
+  .\32xl\:hover\:translate-y-5xl:hover {
+    --tw-translate-y: 8rem;
+  }
+
   .\32xl\:hover\:-translate-y-0:hover {
     --tw-translate-y: 0px;
   }
@@ -100773,6 +117251,50 @@ video {
 
   .\32xl\:hover\:-translate-y-3\.5:hover {
     --tw-translate-y: -0.875rem;
+  }
+
+  .\32xl\:hover\:-translate-y-3xs:hover {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .\32xl\:hover\:-translate-y-xxs:hover {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .\32xl\:hover\:-translate-y-xs:hover {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .\32xl\:hover\:-translate-y-s:hover {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .\32xl\:hover\:-translate-y-m:hover {
+    --tw-translate-y: -1rem;
+  }
+
+  .\32xl\:hover\:-translate-y-l:hover {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .\32xl\:hover\:-translate-y-xl:hover {
+    --tw-translate-y: -2rem;
+  }
+
+  .\32xl\:hover\:-translate-y-xxl:hover {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .\32xl\:hover\:-translate-y-3xl:hover {
+    --tw-translate-y: -3rem;
+  }
+
+  .\32xl\:hover\:-translate-y-4xl:hover {
+    --tw-translate-y: -4rem;
+  }
+
+  .\32xl\:hover\:-translate-y-5xl:hover {
+    --tw-translate-y: -8rem;
   }
 
   .\32xl\:hover\:translate-y-1\/2:hover {
@@ -100971,6 +117493,50 @@ video {
     --tw-translate-x: 0.875rem;
   }
 
+  .\32xl\:focus\:translate-x-3xs:focus {
+    --tw-translate-x: .125rem;
+  }
+
+  .\32xl\:focus\:translate-x-xxs:focus {
+    --tw-translate-x: .25rem;
+  }
+
+  .\32xl\:focus\:translate-x-xs:focus {
+    --tw-translate-x: .5rem;
+  }
+
+  .\32xl\:focus\:translate-x-s:focus {
+    --tw-translate-x: .75rem;
+  }
+
+  .\32xl\:focus\:translate-x-m:focus {
+    --tw-translate-x: 1rem;
+  }
+
+  .\32xl\:focus\:translate-x-l:focus {
+    --tw-translate-x: 1.5rem;
+  }
+
+  .\32xl\:focus\:translate-x-xl:focus {
+    --tw-translate-x: 2rem;
+  }
+
+  .\32xl\:focus\:translate-x-xxl:focus {
+    --tw-translate-x: 2.5rem;
+  }
+
+  .\32xl\:focus\:translate-x-3xl:focus {
+    --tw-translate-x: 3rem;
+  }
+
+  .\32xl\:focus\:translate-x-4xl:focus {
+    --tw-translate-x: 4rem;
+  }
+
+  .\32xl\:focus\:translate-x-5xl:focus {
+    --tw-translate-x: 8rem;
+  }
+
   .\32xl\:focus\:-translate-x-0:focus {
     --tw-translate-x: 0px;
   }
@@ -101109,6 +117675,50 @@ video {
 
   .\32xl\:focus\:-translate-x-3\.5:focus {
     --tw-translate-x: -0.875rem;
+  }
+
+  .\32xl\:focus\:-translate-x-3xs:focus {
+    --tw-translate-x: -0.125rem;
+  }
+
+  .\32xl\:focus\:-translate-x-xxs:focus {
+    --tw-translate-x: -0.25rem;
+  }
+
+  .\32xl\:focus\:-translate-x-xs:focus {
+    --tw-translate-x: -0.5rem;
+  }
+
+  .\32xl\:focus\:-translate-x-s:focus {
+    --tw-translate-x: -0.75rem;
+  }
+
+  .\32xl\:focus\:-translate-x-m:focus {
+    --tw-translate-x: -1rem;
+  }
+
+  .\32xl\:focus\:-translate-x-l:focus {
+    --tw-translate-x: -1.5rem;
+  }
+
+  .\32xl\:focus\:-translate-x-xl:focus {
+    --tw-translate-x: -2rem;
+  }
+
+  .\32xl\:focus\:-translate-x-xxl:focus {
+    --tw-translate-x: -2.5rem;
+  }
+
+  .\32xl\:focus\:-translate-x-3xl:focus {
+    --tw-translate-x: -3rem;
+  }
+
+  .\32xl\:focus\:-translate-x-4xl:focus {
+    --tw-translate-x: -4rem;
+  }
+
+  .\32xl\:focus\:-translate-x-5xl:focus {
+    --tw-translate-x: -8rem;
   }
 
   .\32xl\:focus\:translate-x-1\/2:focus {
@@ -101307,6 +117917,50 @@ video {
     --tw-translate-y: 0.875rem;
   }
 
+  .\32xl\:focus\:translate-y-3xs:focus {
+    --tw-translate-y: .125rem;
+  }
+
+  .\32xl\:focus\:translate-y-xxs:focus {
+    --tw-translate-y: .25rem;
+  }
+
+  .\32xl\:focus\:translate-y-xs:focus {
+    --tw-translate-y: .5rem;
+  }
+
+  .\32xl\:focus\:translate-y-s:focus {
+    --tw-translate-y: .75rem;
+  }
+
+  .\32xl\:focus\:translate-y-m:focus {
+    --tw-translate-y: 1rem;
+  }
+
+  .\32xl\:focus\:translate-y-l:focus {
+    --tw-translate-y: 1.5rem;
+  }
+
+  .\32xl\:focus\:translate-y-xl:focus {
+    --tw-translate-y: 2rem;
+  }
+
+  .\32xl\:focus\:translate-y-xxl:focus {
+    --tw-translate-y: 2.5rem;
+  }
+
+  .\32xl\:focus\:translate-y-3xl:focus {
+    --tw-translate-y: 3rem;
+  }
+
+  .\32xl\:focus\:translate-y-4xl:focus {
+    --tw-translate-y: 4rem;
+  }
+
+  .\32xl\:focus\:translate-y-5xl:focus {
+    --tw-translate-y: 8rem;
+  }
+
   .\32xl\:focus\:-translate-y-0:focus {
     --tw-translate-y: 0px;
   }
@@ -101445,6 +118099,50 @@ video {
 
   .\32xl\:focus\:-translate-y-3\.5:focus {
     --tw-translate-y: -0.875rem;
+  }
+
+  .\32xl\:focus\:-translate-y-3xs:focus {
+    --tw-translate-y: -0.125rem;
+  }
+
+  .\32xl\:focus\:-translate-y-xxs:focus {
+    --tw-translate-y: -0.25rem;
+  }
+
+  .\32xl\:focus\:-translate-y-xs:focus {
+    --tw-translate-y: -0.5rem;
+  }
+
+  .\32xl\:focus\:-translate-y-s:focus {
+    --tw-translate-y: -0.75rem;
+  }
+
+  .\32xl\:focus\:-translate-y-m:focus {
+    --tw-translate-y: -1rem;
+  }
+
+  .\32xl\:focus\:-translate-y-l:focus {
+    --tw-translate-y: -1.5rem;
+  }
+
+  .\32xl\:focus\:-translate-y-xl:focus {
+    --tw-translate-y: -2rem;
+  }
+
+  .\32xl\:focus\:-translate-y-xxl:focus {
+    --tw-translate-y: -2.5rem;
+  }
+
+  .\32xl\:focus\:-translate-y-3xl:focus {
+    --tw-translate-y: -3rem;
+  }
+
+  .\32xl\:focus\:-translate-y-4xl:focus {
+    --tw-translate-y: -4rem;
+  }
+
+  .\32xl\:focus\:-translate-y-5xl:focus {
+    --tw-translate-y: -8rem;
   }
 
   .\32xl\:focus\:translate-y-1\/2:focus {

--- a/gallery.html
+++ b/gallery.html
@@ -4,8 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
+    <link rel="stylesheet" href="dist/tailwind.css" />
+
   </head>
-  <body>
+  <body style= "background-color:#e5e5e5" >
     <!-- Colors -->
     <section></section>
 
@@ -17,10 +19,102 @@
       <div></div>
     </section>
     <!-- Radius -->
-    <section></section>
+    <section class=" my-8 px-8 ">
+      <h2 class="text-xl mb-xl" >
+        Radius
+      </h2>
+      <div class="flex justify-evenly">
+        <div class="items-center ">
+          <p class="text-sm mb-4">Large Radius (16)</p>
+          <div class=" bg-primary h-5xl rounded-lg "></div>
+        </div>
+
+        <div class="items-center ">
+          <p class="text-sm mb-4">Large Radius (8)</p>
+          <div class=" bg-primary h-5xl rounded-md "></div>
+        </div>
+
+        <div class="items-center  ">
+          <p class="text-sm mb-4">Large Radius (4)</p>
+          <div class=" bg-primary h-5xl rounded-sm "></div>
+        </div>
+      </div>
+    </section>
     <!-- Shadows -->
-    <section></section>
+    <section class=" my-8 px-8 " >
+      <h2 class="text-xl mb-xl" >
+        Shadows
+      </h2>
+      <div class="flex justify-evenly">
+        <div class="items-center ">
+          <p class="text-sm mb-4">soft shadow</p>
+          <div style="height:250px;width:250px;background-color: white;" class="shadow-soft  rounded-md "></div>
+        </div>
+
+        <div class="items-center ">
+          <p class="text-sm mb-4">dark shadow</p>
+          <div style="height:250px;width:250px;background-color: white;" class="shadow-dark  rounded-md "></div>
+        </div>
+
+        <div class="items-center  ">
+          <p class="text-sm mb-4">heavy shadow</p>
+          <div style="height:250px;width:250px;background-color: white;" class=" shadow-heavy  rounded-md "></div>
+        </div>
+      </div>
+    </section>
     <!-- Spacing -->
-    <section></section>
-  </body>
+    <section class=" my-8 px-8 ">
+      <h2 class="text-xl mb-xl" >
+        spacing
+      </h2>
+      <div>
+        <div class="flex justify-evenly ">
+          <div class="items-center ">
+            <p class="text-sm">3XS (2)</p>
+            <div class=" bg-primary h-3xs w-3xs "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">XXS (4)</p>
+            <div class=" bg-primary h-xxs w-xxs "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">XS (8)</p>
+            <div class=" bg-primary h-xs w-xs "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">S (12)</p>
+            <div class=" bg-primary h-s w-s "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">S (16)</p>
+            <div class=" bg-primary h-s w-s "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">M (24)</p>
+            <div class=" bg-primary h-m w-m "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">L (32)</p>
+            <div class=" bg-primary h-l w-l "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">XXL (40)</p>
+            <div class=" bg-primary h-xxl w-xxl "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">3XL (48)</p>
+            <div class=" bg-primary h-3xl w-3xl "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">4XL (64)</p>
+            <div class=" bg-primary h-4xl w-4xl "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">5XL (128)</p>
+            <div class=" bg-primary h-5xl w-5xl "></div>
+          </div>
+        </div>
+      </div>
+    </section>
+    </body>
 </html>

--- a/gallery.html
+++ b/gallery.html
@@ -86,16 +86,16 @@
             <div class=" bg-primary h-s w-s "></div>
           </div>
           <div class="items-center ">
-            <p class="text-sm">S (16)</p>
-            <div class=" bg-primary h-s w-s "></div>
-          </div>
-          <div class="items-center ">
-            <p class="text-sm">M (24)</p>
+            <p class="text-sm">M (16)</p>
             <div class=" bg-primary h-m w-m "></div>
           </div>
           <div class="items-center ">
-            <p class="text-sm">L (32)</p>
+            <p class="text-sm">L (24)</p>
             <div class=" bg-primary h-l w-l "></div>
+          </div>
+          <div class="items-center ">
+            <p class="text-sm">xL (32)</p>
+            <div class=" bg-primary h-xl w-xl"></div>
           </div>
           <div class="items-center ">
             <p class="text-sm">XXL (40)</p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,6 +35,21 @@ module.exports = {
       lg: ["2.5rem", { lineHeight: "1.3", letterSpacing: "-.05em" }],
       xl: ["3rem", { lineHeight: "1.3", letterSpacing: "-.05em" }],
     },
+    extend: {
+      spacing: {
+        '3xs': '.125rem',
+        'xxs': '.25rem',
+        'xs': '.5rem',
+        's': '.75rem',
+        'm':'1rem',
+        'l': '1.5rem',
+        'xl': '2rem',
+        'xxl': '2.5rem',
+        '3xl': '3rem',
+        '4xl':'4rem',
+        '5xl':'8rem'
+      }
+    }
   },
   variants: {
     extend: {},


### PR DESCRIPTION
### Description 

- extended default tailwind spaces.

> By default the spacing scale is inherited by the padding, margin, width, height, maxHeight, gap, inset, space, and translate core plugins.
Read more  in [docs](https://tailwindcss.com/docs/customizing-spacing)

- added background-color to the body of `gallyery.html` page
- added three sections as demo for  our customized ( Radius, shadow, spaces ) 
- imported the compiled `tailwind.css` file into `gallery/html` page